### PR TITLE
Fix wrong created_at and updated_at page fields type

### DIFF
--- a/common/migrations/m140703_123104_page.php
+++ b/common/migrations/m140703_123104_page.php
@@ -27,8 +27,8 @@ class m140703_123104_page extends Migration
             'title'=>'About',
             'body'=>'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
             'status'=>\common\models\Page::STATUS_PUBLISHED,
-            'created_at'=>new \yii\db\Expression('NOW()'),
-            'updated_at'=>new \yii\db\Expression('NOW()'),
+            'created_at'=>time(),
+            'updated_at'=>time(),
         ]);
     }
 


### PR DESCRIPTION
При миграции выдло ошибку, что неправильные данные пришли в БД. Посмотрел, и видел что в интовую ячейку приходит datetime.
