### PR TITLE
Fix SystemEvent log data type

### DIFF
--- a/backend/models/SystemEvent.php
+++ b/backend/models/SystemEvent.php
@@ -76,7 +76,7 @@ class SystemEvent extends \yii\db\ActiveRecord
         return ArrayHelper::getValue($messages, $this->getFullEventName());
     }
 
-    public static function log($category, $event, $data = false){
+    public static function log($category, $event, $data = ''){
         $model = new self;
         $model->application = Yii::$app->id;
         $model->category = $category;


### PR DESCRIPTION
Не критично, но все же лучше не злоупотреблять приведением типов. Data имеет тип строки, а закидываем в нее false по дефолту. Да и IDE ругуается на такой расклад.
