### PR TITLE
mysql indices review:

### DIFF
--- a/common/migrations/m140703_123000_user.php
+++ b/common/migrations/m140703_123000_user.php
@@ -62,7 +62,7 @@ class m140703_123000_user extends Migration
         ]);
 
         $this->createTable('{{%user_profile}}', [
-            'user_id' => Schema::TYPE_INTEGER . ' NOT NULL',
+            'user_id' => Schema::TYPE_PK,
             'firstname' => Schema::TYPE_STRING . '(255) ',
             'middlename' => Schema::TYPE_STRING . '(255) ',
             'lastname' => Schema::TYPE_STRING . '(255) ',
@@ -84,8 +84,6 @@ class m140703_123000_user extends Migration
             'locale'=>Yii::$app->sourceLanguage
         ]);
         if ($this->db->driverName === 'mysql') {
-            $this->addPrimaryKey('pk_user_id', '{{%user_profile}}', 'user_id');
-            $this->createIndex('idx_user_id', '{{%user_profile}}', 'user_id');
             $this->addForeignKey('fk_user', '{{%user_profile}}', 'user_id', '{{%user}}', 'id', 'cascade', 'cascade');
         }
 

--- a/common/migrations/m140703_123803_article.php
+++ b/common/migrations/m140703_123803_article.php
@@ -41,7 +41,7 @@ class m140703_123803_article extends Migration
             $this->createIndex('idx_article_author_id', '{{%article}}', 'author_id');
             $this->addForeignKey('fk_article_author', '{{%article}}', 'author_id', '{{%user}}', 'id');
 
-            $this->createIndex('idx_article_updater_id', '{{%article}}', 'author_id');
+            $this->createIndex('idx_article_updater_id', '{{%article}}', 'updater_id');
             $this->addForeignKey('fk_article_updater', '{{%article}}', 'updater_id', '{{%user}}', 'id', 'set null', 'cascade');
 
             $this->createIndex('idx_category_id', '{{%article}}', 'category_id');

--- a/common/migrations/m140709_173333_widget_text.php
+++ b/common/migrations/m140709_173333_widget_text.php
@@ -30,6 +30,13 @@ class m140709_173333_widget_text extends Migration
             'created_at'=> time(),
             'updated_at'=> time(),
         ]);
+
+        if ($this->db->driverName === 'mysql') {
+            $this->createIndex('idx_widget_text_alias', '{{%widget_text}}', 'alias');
+
+            //cache invalidation will use MAX(updated_at)
+            $this->createIndex('idx_widget_text_updated_at', '{{%widget_text}}', 'updated_at');
+        }
     }
 
     public function down()


### PR DESCRIPTION
- user_profile: primary key already build index, no need duplicate
- article: idx_article_updater_id used wrong column
- widget_text: added indices by alias and by updated_at
