### PR TITLE
'message' => 'Uploads' - нет такой фразы.

### DIFF
--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -13,7 +13,6 @@ $config = [
                     'baseUrl' => '@storageUrl',
                     'basePath' => '@storage',
                     'path'   => '/uploads',
-                    'name'   => ['category' => 'app','message' => 'Uploads'], // Yii::t($category, $message)
                     'access' => ['read' => 'manager', 'write' => 'manager'] // * - для всех, иначе проверка доступа в даааном примере все могут видет а редактировать могут пользователи только с правами UserFilesAccess
                 ]
             ]


### PR DESCRIPTION
Ругается нет такой фразы, по дефолту будет Root.
Ещё при выполнении Главная>Записи о файлах>Сбросить файловое хранилище удаляет .gitignore, .htaccess и всё содержимое папки (uploads), которую использует elFinder.
В фрейме с elFinder дублируется debug panel, её как-то можно убрать?