### PR TITLE
Typo bug fixes in `vagrant.sh` and `tests/.env.dist`

### DIFF
--- a/tests/.env.dist
+++ b/tests/.env.dist
@@ -8,7 +8,7 @@ YII_ENV     = tests
 # ---------
 
 DB_DSN           = mysql:host=localhost;port=3306;dbname=yii2-starter-kit-tests
-DB_USER          = root
+DB_USERNAME      = root
 DB_PASSWORD      = root
 DB_TABLE_PREFIX  =
 

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -70,7 +70,7 @@ fi
 
 # Configuring application
 echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'root'" | mysql -uroot -proot
-echo "FLUSH PRIVILEGES'" | mysql -uroot -proot
+echo "FLUSH PRIVILEGES" | mysql -uroot -proot
 echo "CREATE DATABASE IF NOT EXISTS \`yii2-starter-kit\` CHARACTER SET utf8 COLLATE utf8_unicode_ci" | mysql -uroot -proot
 
 php /var/www/console/yii migrate up --interactive=0


### PR DESCRIPTION
* The `FLUSH PRIVILEGES` string has an extra single-quote that causes error when creating new box.
* `tests/.env.dist` has `DB_USER` env var, everywhere else it's `DB_USERNAME` - tests fail