### PR TITLE
#242 fix, one domain nginx config, yii2 migrations update

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -16,6 +16,11 @@ FRONTEND_URL    = http://yii2-starter-kit.dev
 BACKEND_URL     = http://backend.yii2-starter-kit.dev
 STORAGE_URL     = http://storage.yii2-starter-kit.dev
 
+# Urls for one domain
+# FRONTEND_URL    = http://yii2-starter-kit.dev
+# BACKEND_URL     = http://yii2-starter-kit.dev/backend
+# STORAGE_URL     = http://yii2-starter-kit.dev/storage
+
 # Other
 # -----
 FRONTEND_COOKIE_VALIDATION_KEY = <generated_key>

--- a/common/migrations/db/m140703_123000_user.php
+++ b/common/migrations/db/m140703_123000_user.php
@@ -14,29 +14,29 @@ class m140703_123000_user extends Migration
         }
 
         $this->createTable('{{%user}}', [
-            'id' => Schema::primaryKey(),
-            'username' => Schema::string(32),
-            'auth_key' => Schema::string(32)->notNull(),
-            'password_hash' => Schema::string()->notNull(),
-            'password_reset_token' => Schema::string(),
-            'oauth_client' => Schema::string(),
-            'oauth_client_user_id' => Schema::string(),
-            'email' => Schema::string()->notNull(),
-            'status' => Schema::smallInteger()->notNull()->default(User::STATUS_ACTIVE),
-            'created_at' => Schema::integer(),
-            'updated_at' => Schema::integer(),
-            'logged_at' => Schema::integer()
+            'id' => $this->primaryKey(),
+            'username' => $this->string(32),
+            'auth_key' => $this->string(32)->notNull(),
+            'password_hash' => $this->string()->notNull(),
+            'password_reset_token' => $this->string(),
+            'oauth_client' => $this->string(),
+            'oauth_client_user_id' => $this->string(),
+            'email' => $this->string()->notNull(),
+            'status' => $this->smallInteger()->notNull()->defaultValue(User::STATUS_ACTIVE),
+            'created_at' => $this->integer(),
+            'updated_at' => $this->integer(),
+            'logged_at' => $this->integer()
         ], $tableOptions);
 
         $this->createTable('{{%user_profile}}', [
-            'user_id' => Schema::primaryKey(),
-            'firstname' => Schema::string(),
-            'middlename' => Schema::string(),
-            'lastname' => Schema::string(),
-            'avatar_path' => Schema::string(),
-            'avatar_base_url' => Schema::string(),
-            'locale' => Schema::string(32)->notNull(),
-            'gender' => Schema::smallInteger(1)
+            'user_id' => $this->primaryKey(),
+            'firstname' => $this->string(),
+            'middlename' => $this->string(),
+            'lastname' => $this->string(),
+            'avatar_path' => $this->string(),
+            'avatar_base_url' => $this->string(),
+            'locale' => $this->string(32)->notNull(),
+            'gender' => $this->smallInteger(1)
         ], $tableOptions);
 
         $this->addForeignKey('fk_user', '{{%user_profile}}', 'user_id', '{{%user}}', 'id', 'cascade', 'cascade');

--- a/common/migrations/db/m140703_123104_page.php
+++ b/common/migrations/db/m140703_123104_page.php
@@ -13,14 +13,14 @@ class m140703_123104_page extends Migration
         }
 
         $this->createTable('{{%page}}', [
-            'id' => Schema::primaryKey(),
-            'slug' => Schema::string(2048)->notNull(),
-            'title' => Schema::string(512)->notNull(),
-            'body' => Schema::string()->notNull(),
-            'view' => Schema::string(),
-            'status' => Schema::smallInteger()->notNull(),
-            'created_at' => Schema::integer(),
-            'updated_at' => Schema::integer(),
+            'id' => $this->primaryKey(),
+            'slug' => $this->string(2048)->notNull(),
+            'title' => $this->string(512)->notNull(),
+            'body' => $this->string()->notNull(),
+            'view' => $this->string(),
+            'status' => $this->smallInteger()->notNull(),
+            'created_at' => $this->integer(),
+            'updated_at' => $this->integer(),
         ], $tableOptions);
     }
 

--- a/common/migrations/db/m140703_123803_article.php
+++ b/common/migrations/db/m140703_123803_article.php
@@ -13,42 +13,42 @@ class m140703_123803_article extends Migration
         }
 
         $this->createTable('{{%article_category}}', [
-            'id' => Schema::primaryKey(),
-            'slug' => Schema::string(1024)->notNull(),
-            'title' => Schema::string(512)->notNull(),
-            'body' => Schema::text(),
-            'parent_id' => Schema::integer(),
-            'status' => Schema::smallInteger()->notNull()->default(0),
-            'created_at' => Schema::integer(),
-            'updated_at' => Schema::integer(),
+            'id' => $this->primaryKey(),
+            'slug' => $this->string(1024)->notNull(),
+            'title' => $this->string(512)->notNull(),
+            'body' => $this->text(),
+            'parent_id' => $this->integer(),
+            'status' => $this->smallInteger()->notNull()->defaultValue(0),
+            'created_at' => $this->integer(),
+            'updated_at' => $this->integer(),
         ], $tableOptions);
 
         $this->createTable('{{%article}}', [
-            'id' => Schema::primaryKey(),
-            'slug' => Schema::string(1024)->notNull(),
-            'title' => Schema::string(512)->notNull(),
-            'body' => Schema::text()->notNull(),
-            'view' => Schema::string(),
-            'category_id' => Schema::integer(),
-            'thumbnail_base_url' => Schema::string(1024),
-            'thumbnail_path' => Schema::string(1024),
-            'author_id' => Schema::integer(),
-            'updater_id' => Schema::integer(),
-            'status' => Schema::smallInteger()->notNull()->default(0),
-            'published_at' => Schema::integer(),
-            'created_at' => Schema::integer(),
-            'updated_at' => Schema::integer(),
+            'id' => $this->primaryKey(),
+            'slug' => $this->string(1024)->notNull(),
+            'title' => $this->string(512)->notNull(),
+            'body' => $this->text()->notNull(),
+            'view' => $this->string(),
+            'category_id' => $this->integer(),
+            'thumbnail_base_url' => $this->string(1024),
+            'thumbnail_path' => $this->string(1024),
+            'author_id' => $this->integer(),
+            'updater_id' => $this->integer(),
+            'status' => $this->smallInteger()->notNull()->defaultValue(0),
+            'published_at' => $this->integer(),
+            'created_at' => $this->integer(),
+            'updated_at' => $this->integer(),
         ], $tableOptions);
 
         $this->createTable('{{%article_attachment}}', [
-            'id' => Schema::primaryKey(),
-            'article_id' => Schema::integer()->notNull(),
-            'path' => Schema::string()->notNull(),
-            'base_url' => Schema::string(),
-            'type' => Schema::string(),
-            'size' => Schema::integer(),
-            'name' => Schema::string(),
-            'created_at' => Schema::integer()
+            'id' => $this->primaryKey(),
+            'article_id' => $this->integer()->notNull(),
+            'path' => $this->string()->notNull(),
+            'base_url' => $this->string(),
+            'type' => $this->string(),
+            'size' => $this->integer(),
+            'name' => $this->string(),
+            'created_at' => $this->integer()
         ]);
 
         $this->addForeignKey('fk_article_attachment_article', '{{%article_attachment}}', 'article_id', '{{%article}}', 'id', 'cascade', 'cascade');

--- a/common/migrations/db/m140709_173306_widget_menu.php
+++ b/common/migrations/db/m140709_173306_widget_menu.php
@@ -13,11 +13,11 @@ class m140709_173306_widget_menu extends Migration
         }
 
         $this->createTable('{{%widget_menu}}', [
-            'id' => Schema::primaryKey(),
-            'key' => Schema::string(32)->notNull(),
-            'title' => Schema::string()->notNull(),
-            'items' => Schema::text()->notNull(),
-            'status' => Schema::smallInteger()->notNull()->default(0)
+            'id' => $this->primaryKey(),
+            'key' => $this->string(32)->notNull(),
+            'title' => $this->string()->notNull(),
+            'items' => $this->text()->notNull(),
+            'status' => $this->smallInteger()->notNull()->defaultValue(0)
         ], $tableOptions);
     }
 

--- a/common/migrations/db/m140709_173333_widget_text.php
+++ b/common/migrations/db/m140709_173333_widget_text.php
@@ -13,13 +13,13 @@ class m140709_173333_widget_text extends Migration
         }
 
         $this->createTable('{{%widget_text}}', [
-            'id' => Schema::primaryKey(),
-            'key' => Schema::string()->notNull(),
-            'title' => Schema::string()->notNull(),
-            'body' => Schema::text()->notNull(),
-            'status' => Schema::smallInteger(),
-            'created_at' => Schema::integer(),
-            'updated_at' => Schema::integer(),
+            'id' => $this->primaryKey(),
+            'key' => $this->string()->notNull(),
+            'title' => $this->string()->notNull(),
+            'body' => $this->text()->notNull(),
+            'status' => $this->smallInteger(),
+            'created_at' => $this->integer(),
+            'updated_at' => $this->integer(),
         ], $tableOptions);
 
         $this->createIndex('idx_widget_text_key', '{{%widget_text}}', 'key');

--- a/common/migrations/db/m140712_123329_widget_carousel.php
+++ b/common/migrations/db/m140712_123329_widget_carousel.php
@@ -13,23 +13,23 @@ class m140712_123329_widget_carousel extends Migration
         }
 
         $this->createTable('{{%widget_carousel}}', [
-            'id' => Schema::primaryKey(),
-            'key' => Schema::string()->notNull(),
-            'status' => Schema::smallInteger()->default(0)
+            'id' => $this->primaryKey(),
+            'key' => $this->string()->notNull(),
+            'status' => $this->smallInteger()->defaultValue(0)
         ], $tableOptions);
 
         $this->createTable('{{%widget_carousel_item}}', [
-            'id' => Schema::primaryKey(),
-            'carousel_id' => Schema::integer()->notNull(),
-            'base_url'=>Schema::string(1024),
-            'path'=>Schema::string(1024),
-            'type'=>Schema::string(),
-            'url' => Schema::string(1024),
-            'caption' => Schema::string(1024),
-            'status' => Schema::smallInteger()->notNull()->default(0),
-            'order' => Schema::integer()->default(0),
-            'created_at' => Schema::integer(),
-            'updated_at' => Schema::integer(),
+            'id' => $this->primaryKey(),
+            'carousel_id' => $this->integer()->notNull(),
+            'base_url'=>$this->string(1024),
+            'path'=>$this->string(1024),
+            'type'=>$this->string(),
+            'url' => $this->string(1024),
+            'caption' => $this->string(1024),
+            'status' => $this->smallInteger()->notNull()->defaultValue(0),
+            'order' => $this->integer()->defaultValue(0),
+            'created_at' => $this->integer(),
+            'updated_at' => $this->integer(),
         ], $tableOptions);
 
         $this->addForeignKey('fk_item_carousel', '{{%widget_carousel_item}}', 'carousel_id', '{{%widget_carousel}}', 'id', 'cascade', 'cascade');

--- a/common/migrations/db/m140805_084745_key_storage_item.php
+++ b/common/migrations/db/m140805_084745_key_storage_item.php
@@ -13,11 +13,11 @@ class m140805_084745_key_storage_item extends Migration
         }
 
         $this->createTable('{{%key_storage_item}}', [
-            'key' => Schema::string(128)->notNull(),
-            'value' => Schema::text()->notNull(),
-            'comment' => Schema::text(),
-            'updated_at'=>Schema::integer(),
-            'created_at'=>Schema::integer()
+            'key' => $this->string(128)->notNull(),
+            'value' => $this->text()->notNull(),
+            'comment' => $this->text(),
+            'updated_at'=>$this->integer(),
+            'created_at'=>$this->integer()
         ], $tableOptions);
 
         $this->addPrimaryKey('pk_key_storage_item_key', '{{%key_storage_item}}', 'key');

--- a/common/migrations/db/m141012_101932_i18n_tables.php
+++ b/common/migrations/db/m141012_101932_i18n_tables.php
@@ -13,15 +13,15 @@ class m141012_101932_i18n_tables extends Migration
         }
 
         $this->createTable('{{%i18n_source_message}}', [
-            'id'=>Schema::primaryKey(),
-            'category'=>Schema::string(32),
-            'message'=>Schema::text()
+            'id'=>$this->primaryKey(),
+            'category'=>$this->string(32),
+            'message'=>$this->text()
         ], $tableOptions);
 
         $this->createTable('{{%i18n_message}}', [
-            'id'=>Schema::integer(),
-            'language'=>Schema::string(16),
-            'translation'=>Schema::text()
+            'id'=>$this->integer(),
+            'language'=>$this->string(16),
+            'translation'=>$this->text()
         ], $tableOptions);
 
         $this->addPrimaryKey('i18n_message_pk', '{{%i18n_message}}', ['id', 'language']);

--- a/common/migrations/db/m150318_213934_file_storage_item.php
+++ b/common/migrations/db/m150318_213934_file_storage_item.php
@@ -13,15 +13,15 @@ class m150318_213934_file_storage_item extends Migration
         }
 
         $this->createTable('{{%file_storage_item}}', [
-            'id' => Schema::primaryKey(),
-            'component' => Schema::string()->notNull(),
-            'base_url' => Schema::string(1024)->notNull(),
-            'path' => Schema::string(1024)->notNull(),
-            'type' => Schema::string(),
-            'size' => Schema::integer(),
-            'name' => Schema::string(),
-            'upload_ip' => Schema::string(15),
-            'created_at' => Schema::integer()->notNull()
+            'id' => $this->primaryKey(),
+            'component' => $this->string()->notNull(),
+            'base_url' => $this->string(1024)->notNull(),
+            'path' => $this->string(1024)->notNull(),
+            'type' => $this->string(),
+            'size' => $this->integer(),
+            'name' => $this->string(),
+            'upload_ip' => $this->string(15),
+            'created_at' => $this->integer()->notNull()
         ], $tableOptions);
     }
     public function down()

--- a/common/migrations/db/m150414_195800_timeline_event.php
+++ b/common/migrations/db/m150414_195800_timeline_event.php
@@ -13,12 +13,12 @@ class m150414_195800_timeline_event extends Migration
         }
 
         $this->createTable('{{%timeline_event}}', [
-            'id' => Schema::primaryKey(),
-            'application' => Schema::string(64)->notNull(),
-            'category' => Schema::string(64)->notNull(),
-            'event' => Schema::string(64)->notNull(),
-            'data' => Schema::text(),
-            'created_at' => Schema::integer()->notNull()
+            'id' => $this->primaryKey(),
+            'application' => $this->string(64)->notNull(),
+            'category' => $this->string(64)->notNull(),
+            'event' => $this->string(64)->notNull(),
+            'data' => $this->text(),
+            'created_at' => $this->integer()->notNull()
         ], $tableOptions);
 
         $this->createIndex('idx_created_at', '{{%timeline_event}}', 'created_at');

--- a/common/migrations/rbac/m150804_220417_init_roles.php
+++ b/common/migrations/rbac/m150804_220417_init_roles.php
@@ -1,0 +1,19 @@
+<?php
+
+use yii\db\Schema;
+use common\rbac\Migration;
+
+class m150804_220417_init_roles extends Migration
+{
+    public function up()
+    {
+
+    }
+
+    public function down()
+    {
+        echo "m150804_220417_init_roles cannot be reverted.\n";
+
+        return false;
+    }
+}

--- a/vagrant.sh
+++ b/vagrant.sh
@@ -75,6 +75,7 @@ echo "CREATE DATABASE IF NOT EXISTS \`yii2-starter-kit\` CHARACTER SET utf8 COLL
 
 php /var/www/console/yii migrate up --interactive=0
 php /var/www/console/yii rbac/init
+php /var/www/console/yii rbac-migrate/up --interactive=0
 
 sudo service mysql restart
 sudo service php5-fpm restart

--- a/vhost.conf.onedomain
+++ b/vhost.conf.onedomain
@@ -1,0 +1,76 @@
+# Based on https://github.com/mickgeek/yii2-advanced-one-domain-config
+
+upstream php-fpm {
+    server unix:/var/run/php5-fpm.sock;
+}
+
+server {
+    listen       80; # listen for IPv4
+    #listen       [::]:80 ipv6only=on; # listen for IPv6
+    server_name  yii2-starter-kit.dev;
+    root         /var/www;
+
+    charset      utf-8;
+    client_max_body_size  32M;
+
+    # frontend access
+    location / {
+        root  /var/www;
+        try_files  $uri /frontend/web/index.php?$args;
+
+         location ~* ^.+\.(jpg|jpeg|gif|png|ico|css|pdf|ppt|txt|bmp|rtf|js)$ {
+         access_log off;
+         expires max;
+     }
+    }
+
+    # backend access
+    location /backend {
+        #alias  /var/www;
+        try_files  $uri /backend/web/index.php?$args;
+    }
+
+    # storage access
+    location /storage {
+        #alias  /var/www;
+        try_files  $uri /storage/web/index.php?$args;
+
+        location ~* ^/storage/(.+\.php)$ {
+            try_files  $uri /storage/web/$1?$args;
+        }
+
+        # avoid processing of calls to non-existing static files by Yii (uncomment if necessary)
+        location ~* ^/storage/(.+\.(css|js|jpg|jpeg|png|gif|bmp|ico|mov|swf|pdf|zip|rar))$ {
+            try_files  $uri /storage/web/$1?$args;
+        }
+    }
+
+    location ~ \.php$ {
+        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_pass php-fpm;
+        fastcgi_index index.php;
+        include fastcgi_params;
+
+        ## Cache
+        # fastcgi_pass_header Cookie; # fill cookie valiables, $cookie_phpsessid for exmaple
+        # fastcgi_ignore_headers Cache-Control Expires Set-Cookie; # Use it with caution because it is cause SEO problems
+        # fastcgi_cache_key "$request_method|$server_addr:$server_port$request_uri|$cookie_phpsessid"; # generating unique key
+        # fastcgi_cache fastcgi_cache; # use fastcgi_cache keys_zone
+        # fastcgi_cache_path /tmp/nginx/ levels=1:2 keys_zone=fastcgi_cache:16m max_size=256m inactive=1d;
+        # fastcgi_temp_path  /tmp/nginx/temp 1 2; # temp files folder
+        # fastcgi_cache_use_stale updating error timeout invalid_header http_500; # show cached page if error (even if it is outdated)
+        # fastcgi_cache_valid 200 404 10s; # cache lifetime for 200 404;
+        # or fastcgi_cache_valid any 10s; # use it if you want to cache any responses
+    }
+
+    # avoid processing of calls to non-existing static files by Yii for frontend, backend and storage (uncomment if necessary)
+    location ~* \.(css|js|jpg|jpeg|png|gif|bmp|ico|mov|swf|pdf|zip|rar)$ {
+        access_log  off;
+        log_not_found  off;
+        try_files  $uri /frontend/web$uri =404;
+    }
+
+    location ~* \.(htaccess|htpasswd|svn|git) {
+        deny all;
+    }
+}


### PR DESCRIPTION
1. #242 issue: При развороте вагранта на бэкенде вылетает 403 ошибка. Происходит это из-за того, что не накатываются миграции rbac. Поправил это в файле разворота вагранта. 
2. Добавил конфиги для одного домена под nginx: файл vhost.conf.onedomain и несколько строк в .env.dist
3. Несколько дней назад в yii2 @cebe сделал полный рефакторинг Scheme. Теперь при обращении на статические методы вида Scheme:: вываливается fatal error и миграция не проходит. Нужно везде делать $this->. Поправил. 

Документацию пока не трогал, но чуть позже добавлю описание для настройки одного домена.