### PR TITLE
Cache: Use Yii statement throws exception when used in a view. 

### DIFF
--- a/backend/views/cache/index.php
+++ b/backend/views/cache/index.php
@@ -3,7 +3,6 @@
  * Eugine Terentev <eugine@terentev.net>
  * @var \yii\data\ArrayDataProvider $dataProvider
  */
-use Yii;
 use yii\grid\GridView;
 use yii\helpers\Html;
 


### PR DESCRIPTION
Removing it since we don't really need to 'use' it here .
The exception was  “The use statement with non-compound name Yii has no effect”
