### PR TITLE
Nodejs not installed -  Hotfix for the dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,11 @@ RUN docker-php-ext-install zip mcrypt intl mbstring pdo_mysql \
     && docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ \
     && docker-php-ext-install gd
 
-RUN curl -sL https://deb.nodesource.com/setup_0.12 | bash -
+RUN wget -O setupnode.sh https://deb.nodesource.com/setup_0.12
+RUN sh setupnode.sh
+RUN rm setupnode.sh
+RUN apt-get install -y nodejs
+
 RUN curl -sL https://www.npmjs.org/install.sh | bash -
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get --yes install \


### PR DESCRIPTION
Hi, first of all thanks for this awesome starter kit, it's a life saver. Now that you have "dockerized" the starter kit, I tried using it with Docker  but I found that it throws a "nodejs not installed" error when runnning docker-compose build . I fixed it by changing

RUN curl -sL https://deb.nodesource.com/setup_0.12 | bash -

to

RUN wget -O setupnode.sh https://deb.nodesource.com/setup_0.12
RUN sh setupnode.sh
RUN rm setupnode.sh
RUN apt-get install -y nodejs

I am not sure this is the right approach, and I am new to the whole docker thing, so just let me know if you need me to change it to something else. 
Thanks again for all your hard work.

