### PR TITLE
Fixed an exception in the SendEmailCommand.php file . Because the Sen…

### DIFF
--- a/common/commands/command/SendEmailCommand.php
+++ b/common/commands/command/SendEmailCommand.php
@@ -36,10 +36,14 @@ class SendEmailCommand extends BaseCommand
     /**
      * @var bool
      */
-    public $isHtml = true;
+    public $html = true;
 
     public function init()
     {
         $this->from = $this->from ?: \Yii::$app->params['robotEmail'];
+    }
+
+    public function getIsHtml(){
+        return $this->html;
     }
 }

--- a/common/commands/command/SendEmailCommand.php
+++ b/common/commands/command/SendEmailCommand.php
@@ -36,7 +36,7 @@ class SendEmailCommand extends BaseCommand
     /**
      * @var bool
      */
-    public $html = true;
+    public $isHtml = true;
 
     public function init()
     {

--- a/common/commands/handler/SendEmailHandler.php
+++ b/common/commands/handler/SendEmailHandler.php
@@ -20,7 +20,7 @@ class SendEmailHandler extends BaseHandler
             $message = \Yii::$app->mailer->compose($command->view, $command->params);
         } else {
             $message = new Message();
-            if ($command->isHtml) {
+            if ($command->getIsHtml()) {
                 $message->setHtmlBody($command->body);
             } else {
                 $message->setTextBody($command->body);


### PR DESCRIPTION
Hi. Just sending another very small PR.  
I started using the command bus for a project and found an exception when sending emails with it.


Description: 

Since common/commands/handler/SendEmailHandler.php was checking for $command->isHtml , so it was failing because common/commands/command/SendEmailCommand.php defines  $html instead of $isHtml  as a property. 

If you would prefer the property to be $html instead of $isHtml,  I will gladly change the Handler instead of the Command. 

Thanks. 
