### PR TITLE
add immutable for SluggableBehavior to ArticleCategory model

### DIFF
--- a/common/models/ArticleCategory.php
+++ b/common/models/ArticleCategory.php
@@ -45,7 +45,8 @@ class ArticleCategory extends \yii\db\ActiveRecord
             TimestampBehavior::className(),
             [
                 'class'=>SluggableBehavior::className(),
-                'attribute'=>'title'
+                'attribute'=>'title',
+                'immutable' => true
             ]
         ];
     }


### PR DESCRIPTION
При создании новой категории если поле ЧПУ заполнено вручную - генерируется slug из названия, а не тот который указан.  Приходится редактировать slug повторно. Мне кажется пропущена настройка 'immutable' => true для SluggableBehavior в модели ArticleCategory.