### PR TITLE
Spanish Translate Correction

### DIFF
--- a/common/messages/es/backend.php
+++ b/common/messages/es/backend.php
@@ -47,7 +47,7 @@ return [
     'Article Categories' => 'Categorías de Artículo',
     'Articles' => 'Artículos',
     'CPU Usage' => 'Uso de la CPU',
-    'Carousel Widgets' => 'Articugios del carrusel',
+    'Carousel Widgets' => 'Elementos del carrusel',
     'Carousel slide was successfully saved' => 'La diapositiva del carrusel ha sido guardado con éxito',
     'Category' => 'Categoría',
     'Clear' => 'Limpiar',


### PR DESCRIPTION
The word "Articugio" doesn't exist in spanish the traduction in that context is: "Elementos del carousel".