### PR TITLE
Hotfix #363 Deleted references to password_reset_token.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 Yii Starter Kit Change Log
 ==========================
+
+2.1.2
+-----
+- Fixed: #363 Remove references to password_reset_token
+
 2.1.1
 -----
 - Mailcathcer support

--- a/backend/models/search/UserSearch.php
+++ b/backend/models/search/UserSearch.php
@@ -19,7 +19,7 @@ class UserSearch extends User
     {
         return [
             [['id', 'status', 'created_at', 'updated_at', 'logged_at'], 'integer'],
-            [['username', 'auth_key', 'password_hash', 'password_reset_token', 'email'], 'safe'],
+            [['username', 'auth_key', 'password_hash', 'email'], 'safe'],
         ];
     }
 
@@ -59,7 +59,6 @@ class UserSearch extends User
         $query->andFilterWhere(['like', 'username', $this->username])
             ->andFilterWhere(['like', 'auth_key', $this->auth_key])
             ->andFilterWhere(['like', 'password_hash', $this->password_hash])
-            ->andFilterWhere(['like', 'password_reset_token', $this->password_reset_token])
             ->andFilterWhere(['like', 'email', $this->email]);
 
         return $dataProvider;

--- a/backend/views/user/view.php
+++ b/backend/views/user/view.php
@@ -29,7 +29,6 @@ $this->params['breadcrumbs'][] = $this->title;
             'id',
             'username',
             'auth_key',
-            'password_reset_token',
             'email:email',
             'status',
             'is_activated',

--- a/tests/codeception/common/templates/fixtures/user.php
+++ b/tests/codeception/common/templates/fixtures/user.php
@@ -11,7 +11,6 @@ return [
     'email' => $faker->email,
     'auth_key' => $security->generateRandomString(),
     'password_hash' => $security->generatePasswordHash('password_' . $index),
-    'password_reset_token' => $security->generateRandomString() . '_' . time(),
     'created_at' => time(),
     'updated_at' => time(),
 ];


### PR DESCRIPTION
#363 When you delete a field password_reset_token 528eb32 ceased to operate some models.
It is necessary to remove the mention of this field.