### PR TITLE
article attachment migration fix

### DIFF
--- a/common/migrations/db/m140703_123803_article.php
+++ b/common/migrations/db/m140703_123803_article.php
@@ -49,7 +49,7 @@ class m140703_123803_article extends Migration
             'size' => $this->integer(),
             'name' => $this->string(),
             'created_at' => $this->integer()
-        ]);
+        ], $tableOptions);
 
         $this->addForeignKey('fk_article_attachment_article', '{{%article_attachment}}', 'article_id', '{{%article}}', 'id', 'cascade', 'cascade');
         $this->addForeignKey('fk_article_author', '{{%article}}', 'author_id', '{{%user}}', 'id', 'cascade', 'cascade');


### PR DESCRIPTION
Missing $tableOptions param added.
Without it, there are problems with a insert of cyrillic file names (e. g. database from default docker-compose file: `SQLSTATE[HY000]: General error: 1366 Incorrect string value`).