### PR TITLE
Fixes bug with position of badge and right parent arrow in sidebar menu

### DIFF
--- a/backend/widgets/Menu.php
+++ b/backend/widgets/Menu.php
@@ -36,7 +36,7 @@ class Menu extends \yii\widgets\Menu
     /**
      * @var string
      */
-    public $parentRightIcon = '<i class="fa fa-angle-left pull-right"></i>';
+    public $parentRightIcon = '<span class="pull-right-container"><i class="fa fa-angle-left pull-right"></i></span>';
 
     /**
      * @inheritdoc
@@ -59,7 +59,11 @@ class Menu extends \yii\widgets\Menu
 
             return strtr($template, [
                 '{badge}'=> isset($item['badge'])
-                    ? Html::tag('small', $item['badge'], $item['badgeOptions'])
+                    ? Html::tag(
+                        'span',
+                        Html::tag('small', $item['badge'], $item['badgeOptions']),
+                        ['class' => 'pull-right-container']
+                    )
                     : '',
                 '{icon}'=>isset($item['icon']) ? $item['icon'] : '',
                 '{right-icon}'=>isset($item['right-icon']) ? $item['right-icon'] : '',


### PR DESCRIPTION
Badge and right arrow icon is under menu position. This commit fix position of those icons (using the same html code as on admin-lte demo site). 