### PR TITLE
Delete redundant code

### DIFF
--- a/common/models/User.php
+++ b/common/models/User.php
@@ -156,7 +156,7 @@ class User extends ActiveRecord implements IdentityInterface
     {
         return static::find()
             ->active()
-            ->andWhere(['access_token' => $token, 'status' => self::STATUS_ACTIVE])
+            ->andWhere(['access_token' => $token])
             ->one();
     }
 
@@ -170,7 +170,7 @@ class User extends ActiveRecord implements IdentityInterface
     {
         return static::find()
             ->active()
-            ->andWhere(['username' => $username, 'status' => self::STATUS_ACTIVE])
+            ->andWhere(['username' => $username])
             ->one();
     }
 


### PR DESCRIPTION
The method `active` is already contains condition that `status = User::STATUS_ACTIVE`.