### PR TITLE
Automatically use .env BACKEND_URLfor backend request['baseURL'[

### DIFF
--- a/backend/config/web.php
+++ b/backend/config/web.php
@@ -23,7 +23,8 @@ $config = [
             'errorAction' => 'site/error',
         ],
         'request' => [
-            'cookieValidationKey' => env('BACKEND_COOKIE_VALIDATION_KEY')
+            'cookieValidationKey' => env('BACKEND_COOKIE_VALIDATION_KEY'),
+            'baseUrl' => env('BACKEND_URL')
         ],
         'user' => [
             'class'=>'yii\web\User',


### PR DESCRIPTION
Instead of requiring a configuration step automatically use the URL configured in the .env as the backend applications request['baseUrl'] configuration value.