### PR TITLE
Maintenance usability fix. User gets confused with disabled/true

### DIFF
--- a/common/migrations/db/m150725_192740_seed_data.php
+++ b/common/migrations/db/m150725_192740_seed_data.php
@@ -167,7 +167,7 @@ class m150725_192740_seed_data extends Migration
         $this->insert('{{%key_storage_item}}', [
             'key' => 'frontend.maintenance',
             'value' => 'disabled',
-            'comment' => 'Set it to "true" to turn on maintenance mode'
+            'comment' => 'Set it to "enabled" to turn on maintenance mode'
         ]);
 
     }


### PR DESCRIPTION
The string is checked against 'enabled'. But users are informed to set maintenance mode to true.