### PR TITLE
Alter mysql to be mb4

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -13,10 +13,12 @@ DB_DSN           = mysql:host=db;port=3306;dbname=yii2-starter-kit
 DB_USERNAME      = ysk_dbu
 DB_PASSWORD      = ysk_pass
 DB_TABLE_PREFIX  =
+DB_CHARSET       = utf8
 
 TEST_DB_DSN           = mysql:host=localhost;port=3306;dbname=yii2-starter-kit-test
 TEST_DB_USERNAME      = root
 TEST_DB_PASSWORD      = root
+TEST_DB_CHARSET       = utf8
 
 # Urls
 # ----

--- a/common/config/base.php
+++ b/common/config/base.php
@@ -60,7 +60,7 @@ $config = [
             'username' => env('DB_USERNAME'),
             'password' => env('DB_PASSWORD'),
             'tablePrefix' => env('DB_TABLE_PREFIX'),
-            'charset' => 'utf8mb4',
+            'charset' => (env('DB_CHARSET') ? env('DB_CHARSET') : 'utf8'),
             'enableSchemaCache' => YII_ENV_PROD,
         ],
 

--- a/common/config/base.php
+++ b/common/config/base.php
@@ -60,7 +60,7 @@ $config = [
             'username' => env('DB_USERNAME'),
             'password' => env('DB_PASSWORD'),
             'tablePrefix' => env('DB_TABLE_PREFIX'),
-            'charset' => 'utf8',
+            'charset' => 'utf8mb4',
             'enableSchemaCache' => YII_ENV_PROD,
         ],
 

--- a/common/migrations/db/m171018_141344_alterMySQLSchemaToBeMB4.php
+++ b/common/migrations/db/m171018_141344_alterMySQLSchemaToBeMB4.php
@@ -1,0 +1,70 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ *
+ */
+class m171018_141344_alterMySQLSchemaToBeMB4 extends Migration
+{
+    /**
+     *
+     */
+    public function safeUp()
+    {
+        echo __CLASS__ . ' ' . __METHOD__ . ' executing.\n';
+
+        if ($this->db->driverName === 'mysql') {
+            # If this command fails, do not fail the migration, but report a warning
+            $schemaName = explode(';', getenv('DB_DSN'));
+            $schemaName = end(explode('=', end($schemaName)));
+
+            $newCharSet = "utf8mb4";
+            $newCollate = "utf8mb4_unicode_ci";
+
+            $changeSchemaSQL = "
+SELECT *
+FROM information_schema.SCHEMATA
+WHERE DEFAULT_CHARACTER_SET_NAME = '$newCharSet'
+AND DEFAULT_COLLATION_NAME = '$newCollate'
+AND SCHEMA_NAME = '$schemaName';";
+
+            $currentCharSet = $this->execute($changeSchemaSQL);
+
+            if (!empty($currentCharSet)) {
+                return true;
+            }
+
+            # Yii2 does not have a way to alter the database schema nor an `alterTable` AR method
+            # As such AFAIK we have to do this migration using the SQL syntax
+
+            $schemaQuery = "
+ALTER DATABASE
+`" . $schemaName . "`
+CHARACTER SET = $newCharSet
+COLLATE = $newCollate;";
+
+            try {
+                return $this->execute(
+                    $schemaQuery,
+                    "CHARACTER SET utf8 COLLATE $newCollate ENGINE=InnoDB"
+                );
+            } catch (\Exception $e) {
+                echo "\nWARNING: Schema could not be altered automatically. Please run the above query manually, then re-attempt migration(s).\n";
+            }
+
+        }
+
+        return false;
+    }
+
+    /*
+     *
+     */
+    public function safeDown()
+    {
+        echo "m171018_141344_alterMySQLToBeMB4 cannot be reverted.\n";
+
+        return false;
+    }
+}

--- a/common/migrations/db/m171018_141344_alterMySQLSchemaToBeMB4.php
+++ b/common/migrations/db/m171018_141344_alterMySQLSchemaToBeMB4.php
@@ -8,7 +8,7 @@ use yii\db\Migration;
 class m171018_141344_alterMySQLSchemaToBeMB4 extends Migration
 {
     /**
-     *
+     * @return bool|void
      */
     public function safeUp()
     {
@@ -51,8 +51,8 @@ AND SCHEMA_NAME = '$schemaName';";
         return false;
     }
 
-    /*
-     *
+    /**
+     * @return bool
      */
     public function safeDown()
     {

--- a/common/migrations/db/m171018_141344_alterMySQLSchemaToBeMB4.php
+++ b/common/migrations/db/m171018_141344_alterMySQLSchemaToBeMB4.php
@@ -3,12 +3,12 @@
 use yii\db\Migration;
 
 /**
- *
+ * Class m171018_141344_alterMySQLSchemaToBeMB4
  */
 class m171018_141344_alterMySQLSchemaToBeMB4 extends Migration
 {
     /**
-     * @return bool|void
+     * @return bool
      */
     public function safeUp()
     {
@@ -36,16 +36,11 @@ AND SCHEMA_NAME = '$schemaName';";
             }
 
             # Yii2 does not have a way to alter the database schema nor an `alterTable` AR method
-            # As such AFAIK we have to do this migration using the MySQL syntax
-            try {
-                return $this->execute(
-                    "ALTER DATABASE '" . $schemaName . "' CHARACTER SET = $newCharSet COLLATE = $newCollate;",
-                    "CHARACTER SET utf8 COLLATE $newCollate ENGINE=InnoDB"
-                );
-            } catch (\Exception $e) {
-                echo "\nWARNING: Schema could not be altered automatically. Please run the above query manually, then re-attempt migration(s).\n";
-            }
+            # As such AFAIK we have to do this migration using the SQL syntax
+            $command = "ALTER DATABASE `" . $schemaName . "` CHARACTER SET = $newCharSet COLLATE = $newCollate;";
+            $this->execute($command);
 
+            return true;
         }
 
         return false;

--- a/common/migrations/db/m171018_141344_alterMySQLSchemaToBeMB4.php
+++ b/common/migrations/db/m171018_141344_alterMySQLSchemaToBeMB4.php
@@ -36,17 +36,10 @@ AND SCHEMA_NAME = '$schemaName';";
             }
 
             # Yii2 does not have a way to alter the database schema nor an `alterTable` AR method
-            # As such AFAIK we have to do this migration using the SQL syntax
-
-            $schemaQuery = "
-ALTER DATABASE
-`" . $schemaName . "`
-CHARACTER SET = $newCharSet
-COLLATE = $newCollate;";
-
+            # As such AFAIK we have to do this migration using the MySQL syntax
             try {
                 return $this->execute(
-                    $schemaQuery,
+                    "ALTER DATABASE '" . $schemaName . "' CHARACTER SET = $newCharSet COLLATE = $newCollate;",
                     "CHARACTER SET utf8 COLLATE $newCollate ENGINE=InnoDB"
                 );
             } catch (\Exception $e) {

--- a/common/migrations/db/m171018_141344_alterMySQLToBeMB4.php
+++ b/common/migrations/db/m171018_141344_alterMySQLToBeMB4.php
@@ -1,0 +1,196 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ *
+ */
+class m171018_141344_alterMySQLToBeMB4 extends Migration
+{
+    /**
+     *
+     */
+    public function safeUp()
+    {
+        echo __CLASS__ . ' ' . __METHOD__ . ' executing.\n';
+
+        $tableOptions = null;
+        if ($this->db->driverName === 'mysql') {
+            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+
+            # Yii2 does not have a way to alter the database schema nor an `alterTable` AR method
+            # As such AFAIK we have to do this migration using the SQL syntax
+
+            # If this command fails, do not fail the migration, but report a warning
+            $schemaName = explode(';', getenv('DB_DSN'));
+            $schemaName = end(explode('=', end($schemaName)));
+
+            $schemaQuery = "
+ALTER DATABASE
+`" . $schemaName . "``
+CHARACTER SET = utf8mb4
+COLLATE = utf8mb4_unicode_ci;";
+
+            try {
+                $this->execute($schemaQuery, $tableOptions);
+            } catch (\Exception $e) {
+                echo 'WARNING: Schema would not be altered please run $schemaQuery manually.';
+            }
+
+
+            $this->execute("
+            # For each database:
+ALTER DATABASE
+    `yii2-starter-kit`
+    CHARACTER SET = utf8mb4
+    COLLATE = utf8mb4_unicode_ci;
+# Category tables
+ALTER TABLE
+    article
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    article_attachment
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    article_category
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+# Category tables
+ALTER TABLE
+    file_storage_item
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+# i18n
+ALTER TABLE
+    i18n_message
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    i18n_source_message
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+# K/V stores
+ALTER TABLE
+    key_storage_item
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+# PAge table
+ALTER TABLE
+    page
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+#system tables
+ALTER TABLE
+    system_db_migration
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    system_log
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+# user tables
+ALTER TABLE
+    user
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    user_profile
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    user_token
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+# widget tables
+ALTER TABLE
+    widget_carousel
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    widget_carousel_item
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    widget_menu
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    widget_text
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+
+# rbac tables
+# Remove FK's that will not convert properly
+ALTER TABLE rbac_auth_assignment
+  DROP FOREIGN KEY rbac_auth_assignment_ibfk_1;
+
+ALTER TABLE rbac_auth_item
+  DROP FOREIGN KEY rbac_auth_item_ibfk_1;
+
+ALTER TABLE rbac_auth_item_child
+  DROP FOREIGN KEY rbac_auth_item_child_ibfk_1;
+
+ALTER TABLE rbac_auth_item_child
+  DROP FOREIGN KEY rbac_auth_item_child_ibfk_2;
+
+# Alter tables
+ALTER TABLE
+    rbac_auth_assignment
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    rbac_auth_item
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    rbac_auth_item_child
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+ALTER TABLE
+    rbac_auth_rule
+    CONVERT TO CHARACTER SET utf8mb4
+    COLLATE utf8mb4_unicode_ci;
+
+# Re-create FKs
+ALTER TABLE rbac_auth_assignment
+    ADD FOREIGN KEY (item_name) REFERENCES rbac_auth_item(name);
+
+ALTER TABLE rbac_auth_item
+    ADD FOREIGN KEY (rule_name) REFERENCES rbac_auth_rule(name);
+
+ALTER TABLE rbac_auth_item_child
+    ADD FOREIGN KEY (parent) REFERENCES rbac_auth_item(name);
+
+ALTER TABLE rbac_auth_item_child
+    ADD FOREIGN KEY (child) REFERENCES rbac_auth_item(name);
+            ", $tableOptions);
+        }
+    }
+
+    /*
+     *
+     */
+    public function safeDown()
+    {
+        echo "m171018_141344_alterMySQLToBeMB4 cannot be reverted.\n";
+
+        return false;
+    }
+
+    /*
+    // Use up()/down() to run migration code without a transaction.
+    public function up()
+    {
+
+    }
+
+    public function down()
+    {
+        echo "m171018_141344_alterMySQLToBeMB4 cannot be reverted.\n";
+
+        return false;
+    }
+    */
+}

--- a/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
+++ b/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
@@ -158,19 +158,4 @@ ALTER TABLE rbac_auth_item_child
 
         return false;
     }
-
-    /*
-    // Use up()/down() to run migration code without a transaction.
-    public function up()
-    {
-
-    }
-
-    public function down()
-    {
-        echo "m171018_141344_alterMySQLToBeMB4 cannot be reverted.\n";
-
-        return false;
-    }
-    */
 }

--- a/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
+++ b/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
@@ -8,7 +8,7 @@ use yii\db\Migration;
 class m171018_144205_alterMySQLTablesToBeMB4 extends Migration
 {
     /**
-     *
+     * @return bool|void
      */
     public function safeUp()
     {
@@ -149,8 +149,8 @@ ALTER TABLE rbac_auth_item_child
         return false;
     }
 
-    /*
-     *
+    /**
+     * @return bool
      */
     public function safeDown()
     {

--- a/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
+++ b/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
@@ -14,14 +14,8 @@ class m171018_144205_alterMySQLTablesToBeMB4 extends Migration
     {
         echo __CLASS__ . ' ' . __METHOD__ . ' executing.\n';
 
-        $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
-
-            # Yii2 does not have a way to alter the database schema nor an `alterTable` AR method
-            # As such AFAIK we have to do this migration using the SQL syntax
-
-            $this->execute("
+            $command ="
 # Category tables
 ALTER TABLE
     article
@@ -142,8 +136,9 @@ ALTER TABLE rbac_auth_item_child
     ADD FOREIGN KEY (parent) REFERENCES rbac_auth_item(name);
 
 ALTER TABLE rbac_auth_item_child
-    ADD FOREIGN KEY (child) REFERENCES rbac_auth_item(name);
-            ", $tableOptions);
+    ADD FOREIGN KEY (child) REFERENCES rbac_auth_item(name);";
+
+            $this->execute($command);
 
             return true;
         }

--- a/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
+++ b/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
@@ -5,7 +5,7 @@ use yii\db\Migration;
 /**
  *
  */
-class m171018_141344_alterMySQLToBeMB4 extends Migration
+class m171018_144205_alterMySQLTablesToBeMB4 extends Migration
 {
     /**
      *
@@ -21,29 +21,7 @@ class m171018_141344_alterMySQLToBeMB4 extends Migration
             # Yii2 does not have a way to alter the database schema nor an `alterTable` AR method
             # As such AFAIK we have to do this migration using the SQL syntax
 
-            # If this command fails, do not fail the migration, but report a warning
-            $schemaName = explode(';', getenv('DB_DSN'));
-            $schemaName = end(explode('=', end($schemaName)));
-
-            $schemaQuery = "
-ALTER DATABASE
-`" . $schemaName . "``
-CHARACTER SET = utf8mb4
-COLLATE = utf8mb4_unicode_ci;";
-
-            try {
-                $this->execute($schemaQuery, $tableOptions);
-            } catch (\Exception $e) {
-                echo 'WARNING: Schema would not be altered please run $schemaQuery manually.';
-            }
-
-
-            $this->execute("
-            # For each database:
-ALTER DATABASE
-    `yii2-starter-kit`
-    CHARACTER SET = utf8mb4
-    COLLATE = utf8mb4_unicode_ci;
+            return $this->execute("
 # Category tables
 ALTER TABLE
     article
@@ -167,6 +145,8 @@ ALTER TABLE rbac_auth_item_child
     ADD FOREIGN KEY (child) REFERENCES rbac_auth_item(name);
             ", $tableOptions);
         }
+
+        return false;
     }
 
     /*

--- a/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
+++ b/common/migrations/db/m171018_144205_alterMySQLTablesToBeMB4.php
@@ -3,7 +3,7 @@
 use yii\db\Migration;
 
 /**
- *
+ * Class m171018_144205_alterMySQLTablesToBeMB4
  */
 class m171018_144205_alterMySQLTablesToBeMB4 extends Migration
 {
@@ -21,7 +21,7 @@ class m171018_144205_alterMySQLTablesToBeMB4 extends Migration
             # Yii2 does not have a way to alter the database schema nor an `alterTable` AR method
             # As such AFAIK we have to do this migration using the SQL syntax
 
-            return $this->execute("
+            $this->execute("
 # Category tables
 ALTER TABLE
     article
@@ -144,6 +144,8 @@ ALTER TABLE rbac_auth_item_child
 ALTER TABLE rbac_auth_item_child
     ADD FOREIGN KEY (child) REFERENCES rbac_auth_item(name);
             ", $tableOptions);
+
+            return true;
         }
 
         return false;

--- a/common/migrations/db/m171113_115830_alterCommonConfigIfMySQL.php
+++ b/common/migrations/db/m171113_115830_alterCommonConfigIfMySQL.php
@@ -1,0 +1,54 @@
+<?php
+
+use yii\db\Migration;
+
+/**
+ * Class m171018_144205_alterMySQLTablesToBeMB4
+ */
+class m171113_115830_alterCommonConfigIfMySQL extends Migration
+{
+    /**
+     * If the DB engine is MySQL AND the specific two migrations ran successfully, change common/config/base.php db->charset to utf8mb4
+     *
+     * @return bool
+     * @throws \yii\db\Exception
+     */
+    public function safeUp()
+    {
+        echo __CLASS__ . ' ' . __METHOD__ . ' executing.\n';
+
+        // do not proceed if not mysql
+        if ($this->db->driverName !== 'mysql') {
+            return true;
+        }
+
+        // do not proceed if specific migrations did not yet run
+        $migrationCount = \Yii::$app->db->createCommand('
+            SELECT count(*)
+            FROM `systen_migrations`
+            WHERE `value` = `m171018_141344_alterMySQLSchemaToBeMB4`
+              AND `value` = `m171018_144205_alterMySQLTablesToBeMB4`
+        ')->execute();
+        if ($migrationCount !== '2') {
+            return false;
+        }
+
+        // change and save the .env value
+        $dotenv = new Dotenv\Dotenv(__DIR__);
+        $dotenv->overload();
+        $dotenv['DB_CHARSET'] = 'utf8mb4';
+        $dotenv->save();
+
+        return true;
+    }
+
+    /**
+     * @return bool
+     */
+    public function safeDown()
+    {
+        echo "m171113_115830_alterCommonConfigIfMySQL cannot be reverted.\n";
+
+        return false;
+    }
+}

--- a/common/migrations/db/m171113_115830_alterCommonConfigIfMySQL.php
+++ b/common/migrations/db/m171113_115830_alterCommonConfigIfMySQL.php
@@ -23,21 +23,18 @@ class m171113_115830_alterCommonConfigIfMySQL extends Migration
         }
 
         // do not proceed if specific migrations did not yet run
-        $migrationCount = \Yii::$app->db->createCommand('
-            SELECT count(*)
-            FROM `systen_migrations`
-            WHERE `value` = `m171018_141344_alterMySQLSchemaToBeMB4`
-              AND `value` = `m171018_144205_alterMySQLTablesToBeMB4`
-        ')->execute();
-        if ($migrationCount !== '2') {
+        $migrationCount = \Yii::$app->db->createCommand("
+            SELECT *
+            FROM `yii2-starter-kit`.`system_db_migration`
+            WHERE `version` = 'm171018_141344_alterMySQLSchemaToBeMB4'
+              OR `version`  = 'm171018_144205_alterMySQLTablesToBeMB4'
+        ")->queryAll();
+        if (count($migrationCount) !== 2) {
             return false;
         }
 
-        // change and save the .env value
-        $dotenv = new Dotenv\Dotenv(__DIR__);
-        $dotenv->overload();
-        $dotenv['DB_CHARSET'] = 'utf8mb4';
-        $dotenv->save();
+        // change value in .env and reload valuesgit
+
 
         return true;
     }

--- a/common/migrations/db/m171113_115830_alterCommonConfigIfMySQL.php
+++ b/common/migrations/db/m171113_115830_alterCommonConfigIfMySQL.php
@@ -39,7 +39,13 @@ class m171113_115830_alterCommonConfigIfMySQL extends Migration
         if (file_exists($path)) {
             $file_contents = file_get_contents($path);
             $file_contents = str_replace("utf8","utf8mb4", $file_contents);
-            file_put_contents($path, $file_contents);
+
+            if (!$file_contents) {
+                $file_contents = 'DB_CHARSET = utf8mb4';
+                return file_put_contents($path, $file_contents, FILE_APPEND);
+            }
+
+            return file_put_contents($path, $file_contents);
         }
 
         return true;

--- a/common/migrations/db/m171113_115830_alterCommonConfigIfMySQL.php
+++ b/common/migrations/db/m171113_115830_alterCommonConfigIfMySQL.php
@@ -33,8 +33,14 @@ class m171113_115830_alterCommonConfigIfMySQL extends Migration
             return false;
         }
 
-        // change value in .env and reload valuesgit
-
+        // change value in .env and reload values
+        // TODO probably a better way to do this as it is not limiting changes to the DB_CHAR key
+        $path = './.env';
+        if (file_exists($path)) {
+            $file_contents = file_get_contents($path);
+            $file_contents = str_replace("utf8","utf8mb4", $file_contents);
+            file_put_contents($path, $file_contents);
+        }
 
         return true;
     }

--- a/docs/vagrant-files/vagrant/vagrant.sh
+++ b/docs/vagrant-files/vagrant/vagrant.sh
@@ -84,7 +84,7 @@ fi
 # Configuring application
 echo "GRANT ALL PRIVILEGES ON *.* TO 'root'@'%' IDENTIFIED BY 'root'" | mysql -uroot -proot
 echo "FLUSH PRIVILEGES" | mysql -uroot -proot
-echo "CREATE DATABASE IF NOT EXISTS \`yii2-starter-kit\` CHARACTER SET utf8 COLLATE utf8_unicode_ci" | mysql -uroot -proot
+echo "CREATE DATABASE IF NOT EXISTS \`yii2-starter-kit\` CHARACTER SET utf8mb4 COLLATE utf8_unicode_ci" | mysql -uroot -proot
 
 php /var/www/console/yii app/setup --interactive=0
 


### PR DESCRIPTION
When using MySQL the default collation does not fully support UTF-8; this change enabled full UTF-8 support via altering the schema to MySQL UTF-8mb4. This also updates all FKs w/i the original tables as required.

This should pass once https://github.com/trntv/yii2-starter-kit/pull/572 is merged into master.