### PR TITLE
utf8mb4 support

### DIFF
--- a/common/config/base.php
+++ b/common/config/base.php
@@ -60,7 +60,7 @@ $config = [
             'username' => env('DB_USERNAME'),
             'password' => env('DB_PASSWORD'),
             'tablePrefix' => env('DB_TABLE_PREFIX'),
-            'charset' => 'utf8',
+            'charset' => 'utf8mb4',
             'enableSchemaCache' => YII_ENV_PROD,
         ],
 

--- a/common/migrations/db/m140703_123000_user.php
+++ b/common/migrations/db/m140703_123000_user.php
@@ -10,7 +10,7 @@ class m140703_123000_user extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
         }
 
         $this->createTable('{{%user}}', [

--- a/common/migrations/db/m140703_123104_page.php
+++ b/common/migrations/db/m140703_123104_page.php
@@ -9,7 +9,7 @@ class m140703_123104_page extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
         }
 
         $this->createTable('{{%page}}', [

--- a/common/migrations/db/m140703_123803_article.php
+++ b/common/migrations/db/m140703_123803_article.php
@@ -9,7 +9,7 @@ class m140703_123803_article extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
         }
 
         $this->createTable('{{%article_category}}', [

--- a/common/migrations/db/m140709_173306_widget_menu.php
+++ b/common/migrations/db/m140709_173306_widget_menu.php
@@ -9,7 +9,7 @@ class m140709_173306_widget_menu extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
         }
 
         $this->createTable('{{%widget_menu}}', [

--- a/common/migrations/db/m140709_173333_widget_text.php
+++ b/common/migrations/db/m140709_173333_widget_text.php
@@ -9,7 +9,7 @@ class m140709_173333_widget_text extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
         }
 
         $this->createTable('{{%widget_text}}', [

--- a/common/migrations/db/m140712_123329_widget_carousel.php
+++ b/common/migrations/db/m140712_123329_widget_carousel.php
@@ -9,7 +9,7 @@ class m140712_123329_widget_carousel extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
         }
 
         $this->createTable('{{%widget_carousel}}', [

--- a/common/migrations/db/m140805_084745_key_storage_item.php
+++ b/common/migrations/db/m140805_084745_key_storage_item.php
@@ -9,7 +9,7 @@ class m140805_084745_key_storage_item extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci';
         }
 
         $this->createTable('{{%key_storage_item}}', [

--- a/common/migrations/db/m141012_101932_i18n_tables.php
+++ b/common/migrations/db/m141012_101932_i18n_tables.php
@@ -9,7 +9,7 @@ class m141012_101932_i18n_tables extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
         }
 
         $this->createTable('{{%i18n_source_message}}', [

--- a/common/migrations/db/m150318_213934_file_storage_item.php
+++ b/common/migrations/db/m150318_213934_file_storage_item.php
@@ -9,7 +9,7 @@ class m150318_213934_file_storage_item extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_general_ci ENGINE=InnoDB';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_general_ci ENGINE=InnoDB';
         }
 
         $this->createTable('{{%file_storage_item}}', [

--- a/common/migrations/db/m150414_195800_timeline_event.php
+++ b/common/migrations/db/m150414_195800_timeline_event.php
@@ -9,7 +9,7 @@ class m150414_195800_timeline_event extends Migration
     {
         $tableOptions = null;
         if ($this->db->driverName === 'mysql') {
-            $tableOptions = 'CHARACTER SET utf8 COLLATE utf8_unicode_ci ENGINE=InnoDB';
+            $tableOptions = 'CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE=InnoDB';
         }
 
         $this->createTable('{{%timeline_event}}', [


### PR DESCRIPTION
Support `utf8mb4` instead of `utf8`. Fixes #556.

It may be breaking change for developers, but `utf8mb4` is the best practice for long time and we finally want to follow it.

Developers, that are already using `yii2-starter-kit` and wanting to update from template, need to **convert** their database to `utf8mb4`. There is mechanism for it as proposed in #574. It seems like an one-time task for "old-comers".