### PR TITLE
FIX error with null PDO

### DIFF
--- a/backend/views/system-information/index.php
+++ b/backend/views/system-information/index.php
@@ -113,10 +113,10 @@ $this->registerJsFile(
                         <dd><?php echo $provider->getPhpVersion() ?></dd>
 
                         <dt><?php echo Yii::t('backend', 'DB Type') ?></dt>
-                        <dd><?php echo $provider->getDbType(Yii::$app->db->pdo) ?></dd>
+                        <dd><?php echo $provider->getDbType(Yii::$app->db->->getMasterPdo()) ?></dd>
 
                         <dt><?php echo Yii::t('backend', 'DB Version') ?></dt>
-                        <dd><?php echo $provider->getDbVersion(Yii::$app->db->pdo) ?></dd>
+                        <dd><?php echo $provider->getDbVersion(Yii::$app->db->->getMasterPdo()) ?></dd>
                     </dl>
                 </div><!-- /.box-body -->
             </div>


### PR DESCRIPTION
FIX error:   Argument 1 passed to Probe\Provider\AbstractProvider::getDbType() must be an instance of PDO, null given, called in ..../backend/views/system-information/index.php on line 116

Yii2: 2.0.13
php:  7.2.0