### PR TITLE
Prepare for Yii 2.1

### DIFF
--- a/backend/controllers/ArticleCategoryController.php
+++ b/backend/controllers/ArticleCategoryController.php
@@ -19,7 +19,7 @@ class ArticleCategoryController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/controllers/ArticleController.php
+++ b/backend/controllers/ArticleController.php
@@ -19,7 +19,7 @@ class ArticleController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post']
                 ]

--- a/backend/controllers/CacheController.php
+++ b/backend/controllers/CacheController.php
@@ -62,7 +62,7 @@ class CacheController extends Controller
      */
     private function isCacheClass($className)
     {
-        return is_subclass_of($className, Cache::className());
+        return is_subclass_of($className, Cache::class);
     }
 
     /**

--- a/backend/controllers/FileStorageController.php
+++ b/backend/controllers/FileStorageController.php
@@ -18,7 +18,7 @@ class FileStorageController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                     'upload-delete' => ['delete']

--- a/backend/controllers/KeyStorageController.php
+++ b/backend/controllers/KeyStorageController.php
@@ -18,7 +18,7 @@ class KeyStorageController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/controllers/LogController.php
+++ b/backend/controllers/LogController.php
@@ -18,7 +18,7 @@ class LogController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                     'clear' => ['post'],

--- a/backend/controllers/PageController.php
+++ b/backend/controllers/PageController.php
@@ -18,7 +18,7 @@ class PageController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/controllers/SignInController.php
+++ b/backend/controllers/SignInController.php
@@ -27,7 +27,7 @@ class SignInController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'logout' => ['post']
                 ]
@@ -39,7 +39,7 @@ class SignInController extends Controller
     {
         return [
             'avatar-upload' => [
-                'class' => UploadAction::className(),
+                'class' => UploadAction::class,
                 'deleteRoute' => 'avatar-delete',
                 'on afterSave' => function ($event) {
                     /* @var $file \League\Flysystem\File */
@@ -49,7 +49,7 @@ class SignInController extends Controller
                 }
             ],
             'avatar-delete' => [
-                'class' => DeleteAction::className()
+                'class' => DeleteAction::class
             ]
         ];
     }

--- a/backend/controllers/UserController.php
+++ b/backend/controllers/UserController.php
@@ -21,7 +21,7 @@ class UserController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/controllers/WidgetCarouselController.php
+++ b/backend/controllers/WidgetCarouselController.php
@@ -19,7 +19,7 @@ class WidgetCarouselController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post']
                 ],

--- a/backend/controllers/WidgetCarouselItemController.php
+++ b/backend/controllers/WidgetCarouselItemController.php
@@ -25,7 +25,7 @@ class WidgetCarouselItemController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/controllers/WidgetMenuController.php
+++ b/backend/controllers/WidgetMenuController.php
@@ -18,7 +18,7 @@ class WidgetMenuController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/controllers/WidgetTextController.php
+++ b/backend/controllers/WidgetTextController.php
@@ -18,7 +18,7 @@ class WidgetTextController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/models/UserForm.php
+++ b/backend/models/UserForm.php
@@ -29,7 +29,7 @@ class UserForm extends Model
         return [
             ['username', 'filter', 'filter' => 'trim'],
             ['username', 'required'],
-            ['username', 'unique', 'targetClass' => User::className(), 'filter' => function ($query) {
+            ['username', 'unique', 'targetClass' => User::class, 'filter' => function ($query) {
                 if (!$this->getModel()->isNewRecord) {
                     $query->andWhere(['not', ['id' => $this->getModel()->id]]);
                 }
@@ -39,7 +39,7 @@ class UserForm extends Model
             ['email', 'filter', 'filter' => 'trim'],
             ['email', 'required'],
             ['email', 'email'],
-            ['email', 'unique', 'targetClass' => User::className(), 'filter' => function ($query) {
+            ['email', 'unique', 'targetClass' => User::class, 'filter' => function ($query) {
                 if (!$this->getModel()->isNewRecord) {
                     $query->andWhere(['not', ['id' => $this->getModel()->id]]);
                 }

--- a/backend/modules/i18n/controllers/I18nMessageController.php
+++ b/backend/modules/i18n/controllers/I18nMessageController.php
@@ -21,7 +21,7 @@ class I18nMessageController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/modules/i18n/controllers/I18nSourceMessageController.php
+++ b/backend/modules/i18n/controllers/I18nSourceMessageController.php
@@ -18,7 +18,7 @@ class I18nSourceMessageController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/modules/i18n/models/I18nMessage.php
+++ b/backend/modules/i18n/models/I18nMessage.php
@@ -35,7 +35,7 @@ class I18nMessage extends \yii\db\ActiveRecord
     {
         return [
             [['id', 'language'], 'required'],
-            [['id'], 'exist', 'targetClass' => I18nSourceMessage::className(), 'targetAttribute' => 'id'],
+            [['id'], 'exist', 'targetClass' => I18nSourceMessage::class, 'targetAttribute' => 'id'],
             [['translation'], 'string'],
             [['language'], 'string', 'max' => 16],
             [['language'], 'unique', 'targetAttribute' => ['id', 'language']]
@@ -69,6 +69,6 @@ class I18nMessage extends \yii\db\ActiveRecord
      */
     public function getSourceMessageModel()
     {
-        return $this->hasOne(I18nSourceMessage::className(), ['id' => 'id']);
+        return $this->hasOne(I18nSourceMessage::class, ['id' => 'id']);
     }
 }

--- a/backend/modules/i18n/models/I18nSourceMessage.php
+++ b/backend/modules/i18n/models/I18nSourceMessage.php
@@ -51,6 +51,6 @@ class I18nSourceMessage extends \yii\db\ActiveRecord
      */
     public function getI18nMessages()
     {
-        return $this->hasMany(I18nMessage::className(), ['id' => 'id']);
+        return $this->hasMany(I18nMessage::class, ['id' => 'id']);
     }
 }

--- a/backend/modules/rbac/controllers/RbacAuthAssignmentController.php
+++ b/backend/modules/rbac/controllers/RbacAuthAssignmentController.php
@@ -18,7 +18,7 @@ class RbacAuthAssignmentController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/modules/rbac/controllers/RbacAuthItemChildController.php
+++ b/backend/modules/rbac/controllers/RbacAuthItemChildController.php
@@ -21,7 +21,7 @@ class RbacAuthItemChildController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['POST'],
                 ],

--- a/backend/modules/rbac/controllers/RbacAuthItemController.php
+++ b/backend/modules/rbac/controllers/RbacAuthItemController.php
@@ -21,7 +21,7 @@ class RbacAuthItemController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['POST'],
                 ],

--- a/backend/modules/rbac/controllers/RbacAuthRuleController.php
+++ b/backend/modules/rbac/controllers/RbacAuthRuleController.php
@@ -21,7 +21,7 @@ class RbacAuthRuleController extends Controller
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['POST'],
                 ],

--- a/backend/modules/rbac/models/RbacAuthAssignment.php
+++ b/backend/modules/rbac/models/RbacAuthAssignment.php
@@ -32,7 +32,7 @@ class RbacAuthAssignment extends \yii\db\ActiveRecord
             [['item_name', 'user_id'], 'required'],
             [['created_at'], 'integer'],
             [['item_name', 'user_id'], 'string', 'max' => 64],
-            [['item_name'], 'exist', 'skipOnError' => true, 'targetClass' => RbacAuthItem::className(), 'targetAttribute' => ['item_name' => 'name']],
+            [['item_name'], 'exist', 'skipOnError' => true, 'targetClass' => RbacAuthItem::class, 'targetAttribute' => ['item_name' => 'name']],
         ];
     }
 
@@ -53,6 +53,6 @@ class RbacAuthAssignment extends \yii\db\ActiveRecord
      */
     public function getItemName()
     {
-        return $this->hasOne(RbacAuthItem::className(), ['name' => 'item_name']);
+        return $this->hasOne(RbacAuthItem::class, ['name' => 'item_name']);
     }
 }

--- a/backend/modules/rbac/models/RbacAuthItem.php
+++ b/backend/modules/rbac/models/RbacAuthItem.php
@@ -42,7 +42,7 @@ class RbacAuthItem extends \yii\db\ActiveRecord
             [['type', 'created_at', 'updated_at'], 'integer'],
             [['description', 'data'], 'string'],
             [['name', 'rule_name'], 'string', 'max' => 64],
-            [['rule_name'], 'exist', 'skipOnError' => true, 'targetClass' => RbacAuthRule::className(), 'targetAttribute' => ['rule_name' => 'name']],
+            [['rule_name'], 'exist', 'skipOnError' => true, 'targetClass' => RbacAuthRule::class, 'targetAttribute' => ['rule_name' => 'name']],
         ];
     }
 
@@ -67,7 +67,7 @@ class RbacAuthItem extends \yii\db\ActiveRecord
      */
     public function getRbacAuthAssignments()
     {
-        return $this->hasMany(RbacAuthAssignment::className(), ['item_name' => 'name']);
+        return $this->hasMany(RbacAuthAssignment::class, ['item_name' => 'name']);
     }
 
     /**
@@ -75,7 +75,7 @@ class RbacAuthItem extends \yii\db\ActiveRecord
      */
     public function getRuleName()
     {
-        return $this->hasOne(RbacAuthRule::className(), ['name' => 'rule_name']);
+        return $this->hasOne(RbacAuthRule::class, ['name' => 'rule_name']);
     }
 
     /**
@@ -83,7 +83,7 @@ class RbacAuthItem extends \yii\db\ActiveRecord
      */
     public function getRbacAuthItemChildren()
     {
-        return $this->hasMany(RbacAuthItemChild::className(), ['parent' => 'name']);
+        return $this->hasMany(RbacAuthItemChild::class, ['parent' => 'name']);
     }
 
     /**
@@ -91,7 +91,7 @@ class RbacAuthItem extends \yii\db\ActiveRecord
      */
     public function getRbacAuthItemChildren0()
     {
-        return $this->hasMany(RbacAuthItemChild::className(), ['child' => 'name']);
+        return $this->hasMany(RbacAuthItemChild::class, ['child' => 'name']);
     }
 
     /**
@@ -99,7 +99,7 @@ class RbacAuthItem extends \yii\db\ActiveRecord
      */
     public function getChildren()
     {
-        return $this->hasMany(RbacAuthItem::className(), ['name' => 'child'])->viaTable('rbac_auth_item_child', ['parent' => 'name']);
+        return $this->hasMany(RbacAuthItem::class, ['name' => 'child'])->viaTable('rbac_auth_item_child', ['parent' => 'name']);
     }
 
     /**
@@ -107,6 +107,6 @@ class RbacAuthItem extends \yii\db\ActiveRecord
      */
     public function getParents()
     {
-        return $this->hasMany(RbacAuthItem::className(), ['name' => 'parent'])->viaTable('rbac_auth_item_child', ['child' => 'name']);
+        return $this->hasMany(RbacAuthItem::class, ['name' => 'parent'])->viaTable('rbac_auth_item_child', ['child' => 'name']);
     }
 }

--- a/backend/modules/rbac/models/RbacAuthItemChild.php
+++ b/backend/modules/rbac/models/RbacAuthItemChild.php
@@ -31,8 +31,8 @@ class RbacAuthItemChild extends \yii\db\ActiveRecord
         return [
             [['parent', 'child'], 'required'],
             [['parent', 'child'], 'string', 'max' => 64],
-            [['parent'], 'exist', 'skipOnError' => true, 'targetClass' => RbacAuthItem::className(), 'targetAttribute' => ['parent' => 'name']],
-            [['child'], 'exist', 'skipOnError' => true, 'targetClass' => RbacAuthItem::className(), 'targetAttribute' => ['child' => 'name']],
+            [['parent'], 'exist', 'skipOnError' => true, 'targetClass' => RbacAuthItem::class, 'targetAttribute' => ['parent' => 'name']],
+            [['child'], 'exist', 'skipOnError' => true, 'targetClass' => RbacAuthItem::class, 'targetAttribute' => ['child' => 'name']],
         ];
     }
 
@@ -52,7 +52,7 @@ class RbacAuthItemChild extends \yii\db\ActiveRecord
      */
     public function getParent0()
     {
-        return $this->hasOne(RbacAuthItem::className(), ['name' => 'parent']);
+        return $this->hasOne(RbacAuthItem::class, ['name' => 'parent']);
     }
 
     /**
@@ -60,6 +60,6 @@ class RbacAuthItemChild extends \yii\db\ActiveRecord
      */
     public function getChild0()
     {
-        return $this->hasOne(RbacAuthItem::className(), ['name' => 'child']);
+        return $this->hasOne(RbacAuthItem::class, ['name' => 'child']);
     }
 }

--- a/backend/modules/rbac/models/RbacAuthRule.php
+++ b/backend/modules/rbac/models/RbacAuthRule.php
@@ -55,6 +55,6 @@ class RbacAuthRule extends \yii\db\ActiveRecord
      */
     public function getRbacAuthItems()
     {
-        return $this->hasMany(RbacAuthItem::className(), ['rule_name' => 'name']);
+        return $this->hasMany(RbacAuthItem::class, ['rule_name' => 'name']);
     }
 }

--- a/backend/views/_gii/templates/controller.php
+++ b/backend/views/_gii/templates/controller.php
@@ -49,7 +49,7 @@ class <?php echo $controllerClass ?> extends <?php echo StringHelper::basename($
     {
         return [
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'delete' => ['post'],
                 ],

--- a/backend/views/article/_form.php
+++ b/backend/views/article/_form.php
@@ -28,7 +28,7 @@ use yii\bootstrap\ActiveForm;
         ), ['prompt'=>'']) ?>
 
     <?php echo $form->field($model, 'body')->widget(
-        \yii\imperavi\Widget::className(),
+        \yii\imperavi\Widget::class,
         [
             'plugins' => ['fullscreen', 'fontcolor', 'video'],
             'options' => [
@@ -43,7 +43,7 @@ use yii\bootstrap\ActiveForm;
     ) ?>
 
     <?php echo $form->field($model, 'thumbnail')->widget(
-        Upload::className(),
+        Upload::class,
         [
             'url' => ['/file-storage/upload'],
             'maxFileSize' => 5000000, // 5 MiB
@@ -51,7 +51,7 @@ use yii\bootstrap\ActiveForm;
     ?>
 
     <?php echo $form->field($model, 'attachments')->widget(
-        Upload::className(),
+        Upload::class,
         [
             'url' => ['/file-storage/upload'],
             'sortable' => true,
@@ -65,7 +65,7 @@ use yii\bootstrap\ActiveForm;
     <?php echo $form->field($model, 'status')->checkbox() ?>
 
     <?php echo $form->field($model, 'published_at')->widget(
-        DateTimeWidget::className(),
+        DateTimeWidget::class,
         [
             'phpDatetimeFormat' => 'yyyy-MM-dd\'T\'HH:mm:ssZZZZZ'
         ]

--- a/backend/views/article/index.php
+++ b/backend/views/article/index.php
@@ -48,7 +48,7 @@ $this->params['breadcrumbs'][] = $this->title;
                 }
             ],
             [
-                'class' => EnumColumn::className(),
+                'class' => EnumColumn::class,
                 'attribute' => 'status',
                 'enum' => [
                     Yii::t('backend', 'Not Published'),

--- a/backend/views/page/_form.php
+++ b/backend/views/page/_form.php
@@ -17,7 +17,7 @@ use yii\bootstrap\ActiveForm;
     <?php echo $form->field($model, 'slug')->textInput(['maxlength' => true]) ?>
 
     <?php echo $form->field($model, 'body')->widget(
-        \yii\imperavi\Widget::className(),
+        \yii\imperavi\Widget::class,
         [
             'plugins' => ['fullscreen', 'fontcolor', 'video'],
             'options'=>[

--- a/backend/views/sign-in/profile.php
+++ b/backend/views/sign-in/profile.php
@@ -15,7 +15,7 @@ $this->title = Yii::t('backend', 'Edit profile')
 
     <?php $form = ActiveForm::begin(); ?>
 
-    <?php echo $form->field($model, 'picture')->widget(\trntv\filekit\widget\Upload::classname(), [
+    <?php echo $form->field($model, 'picture')->widget(\trntv\filekit\widget\Upload::class, [
         'url'=>['avatar-upload']
     ]) ?>
 

--- a/backend/views/timeline-event/index.php
+++ b/backend/views/timeline-event/index.php
@@ -30,7 +30,7 @@ $icons = [
                             try {
                                 $viewFile = sprintf('%s/%s', $model->category, $model->event);
                                 echo $this->render($viewFile, ['model' => $model]);
-                            } catch (\yii\base\InvalidParamException $e) {
+                            } catch (\yii\base\InvalidArgumentException $e) {
                                 echo $this->render('_item', ['model' => $model]);
                             }
                         ?>

--- a/backend/views/user/index.php
+++ b/backend/views/user/index.php
@@ -33,7 +33,7 @@ $this->params['breadcrumbs'][] = $this->title;
             'username',
             'email:email',
             [
-                'class' => EnumColumn::className(),
+                'class' => EnumColumn::class,
                 'attribute' => 'status',
                 'enum' => User::statuses(),
                 'filter' => User::statuses()

--- a/backend/views/widget-carousel/index.php
+++ b/backend/views/widget-carousel/index.php
@@ -30,7 +30,7 @@ $this->params['breadcrumbs'][] = $this->title;
             'id',
             'key',
             [
-                'class'=>\common\grid\EnumColumn::className(),
+                'class'=>\common\grid\EnumColumn::class,
                 'attribute'=>'status',
                 'enum'=>[
                     Yii::t('backend', 'Disabled'),

--- a/backend/views/widget-carousel/item/_form.php
+++ b/backend/views/widget-carousel/item/_form.php
@@ -15,7 +15,7 @@ use yii\helpers\Html;
     <?php echo $form->errorSummary($model) ?>
 
     <?php echo $form->field($model, 'image')->widget(
-        \trntv\filekit\widget\Upload::className(),
+        \trntv\filekit\widget\Upload::class,
         [
             'url'=>['/file-storage/upload'],
         ]
@@ -26,7 +26,7 @@ use yii\helpers\Html;
     <?php echo $form->field($model, 'url')->textInput(['maxlength' => 1024]) ?>
 
     <?php echo $form->field($model, 'caption')->widget(
-        \yii\imperavi\Widget::className(),
+        \yii\imperavi\Widget::class,
         [
             'plugins' => ['fullscreen', 'fontcolor', 'video'],
             'options' => [

--- a/backend/views/widget-menu/_form.php
+++ b/backend/views/widget-menu/_form.php
@@ -19,7 +19,7 @@ use yii\bootstrap\ActiveForm;
     <?php echo $form->field($model, 'title')->textInput(['maxlength' => 512]) ?>
 
     <?php echo $form->field($model, 'items')->widget(
-        trntv\aceeditor\AceEditor::className(),
+        trntv\aceeditor\AceEditor::class,
         [
             'mode' => 'json'
         ]

--- a/backend/views/widget-menu/index.php
+++ b/backend/views/widget-menu/index.php
@@ -31,7 +31,7 @@ $this->params['breadcrumbs'][] = $this->title;
             'title',
             'key',
             [
-                'class'=>\common\grid\EnumColumn::className(),
+                'class'=>\common\grid\EnumColumn::class,
                 'attribute'=>'status',
                 'enum'=>[
                     Yii::t('backend', 'Disabled'),

--- a/backend/views/widget-text/_form.php
+++ b/backend/views/widget-text/_form.php
@@ -17,7 +17,7 @@ use yii\bootstrap\ActiveForm;
     <?php echo $form->field($model, 'title')->textInput(['maxlength' => 512]) ?>
 
     <?php echo $form->field($model, 'body')->widget(
-        trntv\aceeditor\AceEditor::className(),
+        trntv\aceeditor\AceEditor::class,
         [
             'mode' => 'html'
         ]

--- a/backend/views/widget-text/index.php
+++ b/backend/views/widget-text/index.php
@@ -30,7 +30,7 @@ $this->params['breadcrumbs'][] = $this->title;
             'key',
             'title',
             [
-                'class'=>\common\grid\EnumColumn::className(),
+                'class'=>\common\grid\EnumColumn::class,
                 'attribute'=>'status',
                 'enum'=>[
                     Yii::t('backend', 'Disabled'),

--- a/common/actions/SetLocaleAction.php
+++ b/common/actions/SetLocaleAction.php
@@ -7,7 +7,7 @@ namespace common\actions;
 
 use Yii;
 use yii\base\Action;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\web\Cookie;
 
 /**
@@ -67,7 +67,7 @@ class SetLocaleAction extends Action
     public function run($locale)
     {
         if (!is_array($this->locales) || !in_array($locale, $this->locales, true)) {
-            throw new InvalidParamException('Unacceptable locale');
+            throw new InvalidArgumentException('Unacceptable locale');
         }
         $cookie = new Cookie([
             'name' => $this->localeCookieName,

--- a/common/behaviors/CacheInvalidateBehavior.php
+++ b/common/behaviors/CacheInvalidateBehavior.php
@@ -16,7 +16,7 @@ use yii\db\ActiveRecord;
  * {
  *     return [
  *         [
- *             'class' => CacheInvalidateBehavior::className(),
+ *             'class' => CacheInvalidateBehavior::class,
  *             'tags' => [
  *                  'awesomeTag',
  *                   function($model){

--- a/common/components/keyStorage/FormModel.php
+++ b/common/components/keyStorage/FormModel.php
@@ -4,7 +4,7 @@ namespace common\components\keyStorage;
 
 use Yii;
 use yii\base\Exception;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\base\Model;
 use yii\helpers\ArrayHelper;
 use yii\helpers\Inflector;
@@ -92,7 +92,7 @@ class FormModel extends Model
      * Sets the named attribute value.
      * @param string $name the attribute name
      * @param mixed $value the attribute value.
-     * @throws InvalidParamException if the named attribute does not exist.
+     * @throws InvalidArgumentException if the named attribute does not exist.
      * @see hasAttribute()
      */
     public function setAttribute($name, $value)
@@ -100,7 +100,7 @@ class FormModel extends Model
         if ($this->hasAttribute($name)) {
             $this->attributes[$name] = $value;
         } else {
-            throw new InvalidParamException(get_class($this) . ' has no attribute named "' . $name . '".');
+            throw new InvalidArgumentException(get_class($this) . ' has no attribute named "' . $name . '".');
         }
     }
 
@@ -204,7 +204,7 @@ class FormModel extends Model
      * This method is overridden so that attributes and related objects can be accessed like properties.
      *
      * @param string $name property name
-     * @throws \yii\base\InvalidParamException if relation name is wrong
+     * @throws \yii\base\InvalidArgumentException if relation name is wrong
      * @return mixed property value
      * @see getAttribute()
      */

--- a/common/models/Article.php
+++ b/common/models/Article.php
@@ -71,15 +71,15 @@ class Article extends ActiveRecord
     public function behaviors()
     {
         return [
-            TimestampBehavior::className(),
-            BlameableBehavior::className(),
+            TimestampBehavior::class,
+            BlameableBehavior::class,
             [
-                'class' => SluggableBehavior::className(),
+                'class' => SluggableBehavior::class,
                 'attribute' => 'title',
                 'immutable' => true
             ],
             [
-                'class' => UploadBehavior::className(),
+                'class' => UploadBehavior::class,
                 'attribute' => 'attachments',
                 'multiple' => true,
                 'uploadRelation' => 'articleAttachments',
@@ -91,7 +91,7 @@ class Article extends ActiveRecord
                 'nameAttribute' => 'name',
             ],
             [
-                'class' => UploadBehavior::className(),
+                'class' => UploadBehavior::class,
                 'attribute' => 'thumbnail',
                 'pathAttribute' => 'thumbnail_path',
                 'baseUrlAttribute' => 'thumbnail_base_url'
@@ -112,7 +112,7 @@ class Article extends ActiveRecord
                 return date(DATE_ISO8601);
             }],
             [['published_at'], 'filter', 'filter' => 'strtotime', 'skipOnEmpty' => true],
-            [['category_id'], 'exist', 'targetClass' => ArticleCategory::className(), 'targetAttribute' => 'id'],
+            [['category_id'], 'exist', 'targetClass' => ArticleCategory::class, 'targetAttribute' => 'id'],
             [['status'], 'integer'],
             [['slug', 'thumbnail_base_url', 'thumbnail_path'], 'string', 'max' => 1024],
             [['title'], 'string', 'max' => 512],
@@ -148,7 +148,7 @@ class Article extends ActiveRecord
      */
     public function getAuthor()
     {
-        return $this->hasOne(User::className(), ['id' => 'created_by']);
+        return $this->hasOne(User::class, ['id' => 'created_by']);
     }
 
     /**
@@ -156,7 +156,7 @@ class Article extends ActiveRecord
      */
     public function getUpdater()
     {
-        return $this->hasOne(User::className(), ['id' => 'updated_by']);
+        return $this->hasOne(User::class, ['id' => 'updated_by']);
     }
 
     /**
@@ -164,7 +164,7 @@ class Article extends ActiveRecord
      */
     public function getCategory()
     {
-        return $this->hasOne(ArticleCategory::className(), ['id' => 'category_id']);
+        return $this->hasOne(ArticleCategory::class, ['id' => 'category_id']);
     }
 
     /**
@@ -172,6 +172,6 @@ class Article extends ActiveRecord
      */
     public function getArticleAttachments()
     {
-        return $this->hasMany(ArticleAttachment::className(), ['article_id' => 'id']);
+        return $this->hasMany(ArticleAttachment::class, ['article_id' => 'id']);
     }
 }

--- a/common/models/ArticleAttachment.php
+++ b/common/models/ArticleAttachment.php
@@ -38,7 +38,7 @@ class ArticleAttachment extends ActiveRecord
     {
         return [
             [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'updatedAtAttribute' => false
             ]
         ];
@@ -78,7 +78,7 @@ class ArticleAttachment extends ActiveRecord
      */
     public function getArticle()
     {
-        return $this->hasOne(Article::className(), ['id' => 'article_id']);
+        return $this->hasOne(Article::class, ['id' => 'article_id']);
     }
 
     public function getUrl()

--- a/common/models/ArticleCategory.php
+++ b/common/models/ArticleCategory.php
@@ -43,9 +43,9 @@ class ArticleCategory extends ActiveRecord
     public function behaviors()
     {
         return [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
             [
-                'class' => SluggableBehavior::className(),
+                'class' => SluggableBehavior::class,
                 'attribute' => 'title',
                 'immutable' => true
             ]
@@ -64,7 +64,7 @@ class ArticleCategory extends ActiveRecord
             [['slug'], 'unique'],
             [['slug'], 'string', 'max' => 1024],
             ['status', 'integer'],
-            ['parent_id', 'exist', 'targetClass' => ArticleCategory::className(), 'targetAttribute' => 'id']
+            ['parent_id', 'exist', 'targetClass' => ArticleCategory::class, 'targetAttribute' => 'id']
         ];
     }
 
@@ -87,7 +87,7 @@ class ArticleCategory extends ActiveRecord
      */
     public function getArticles()
     {
-        return $this->hasMany(Article::className(), ['category_id' => 'id']);
+        return $this->hasMany(Article::class, ['category_id' => 'id']);
     }
 
     /**
@@ -95,6 +95,6 @@ class ArticleCategory extends ActiveRecord
      */
     public function getParent()
     {
-        return $this->hasMany(ArticleCategory::className(), ['id' => 'parent_id']);
+        return $this->hasMany(ArticleCategory::class, ['id' => 'parent_id']);
     }
 }

--- a/common/models/FileStorageItem.php
+++ b/common/models/FileStorageItem.php
@@ -33,7 +33,7 @@ class FileStorageItem extends ActiveRecord
     {
         return [
             [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'updatedAtAttribute' => false
             ]
         ];

--- a/common/models/KeyStorageItem.php
+++ b/common/models/KeyStorageItem.php
@@ -26,7 +26,7 @@ class KeyStorageItem extends ActiveRecord
     {
         return [
             [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
             ],
         ];
     }

--- a/common/models/Page.php
+++ b/common/models/Page.php
@@ -38,9 +38,9 @@ class Page extends ActiveRecord
     public function behaviors()
     {
         return [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
             'slug' => [
-                'class' => SluggableBehavior::className(),
+                'class' => SluggableBehavior::class,
                 'attribute' => 'title',
                 'ensureUnique' => true,
                 'immutable' => true

--- a/common/models/TimelineEvent.php
+++ b/common/models/TimelineEvent.php
@@ -41,7 +41,7 @@ class TimelineEvent extends ActiveRecord
     {
         return [
             'timestamp' => [
-                'class' => TimestampBehavior::className(),
+                'class' => TimestampBehavior::class,
                 'createdAtAttribute' => 'created_at',
                 'updatedAtAttribute' => null
             ]

--- a/common/models/User.php
+++ b/common/models/User.php
@@ -116,16 +116,16 @@ class User extends ActiveRecord implements IdentityInterface
     public function behaviors()
     {
         return [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
             'auth_key' => [
-                'class' => AttributeBehavior::className(),
+                'class' => AttributeBehavior::class,
                 'attributes' => [
                     ActiveRecord::EVENT_BEFORE_INSERT => 'auth_key'
                 ],
                 'value' => Yii::$app->getSecurity()->generateRandomString()
             ],
             'access_token' => [
-                'class' => AttributeBehavior::className(),
+                'class' => AttributeBehavior::class,
                 'attributes' => [
                     ActiveRecord::EVENT_BEFORE_INSERT => 'access_token'
                 ],
@@ -198,7 +198,7 @@ class User extends ActiveRecord implements IdentityInterface
      */
     public function getUserProfile()
     {
-        return $this->hasOne(UserProfile::className(), ['user_id' => 'id']);
+        return $this->hasOne(UserProfile::class, ['user_id' => 'id']);
     }
 
     /**

--- a/common/models/UserProfile.php
+++ b/common/models/UserProfile.php
@@ -47,7 +47,7 @@ class UserProfile extends ActiveRecord
     {
         return [
             'picture' => [
-                'class' => UploadBehavior::className(),
+                'class' => UploadBehavior::class,
                 'attribute' => 'picture',
                 'pathAttribute' => 'avatar_path',
                 'baseUrlAttribute' => 'avatar_base_url'
@@ -92,7 +92,7 @@ class UserProfile extends ActiveRecord
      */
     public function getUser()
     {
-        return $this->hasOne(User::className(), ['id' => 'user_id']);
+        return $this->hasOne(User::class, ['id' => 'user_id']);
     }
 
     /**

--- a/common/models/UserToken.php
+++ b/common/models/UserToken.php
@@ -101,7 +101,7 @@ class UserToken extends ActiveRecord
     public function behaviors()
     {
         return [
-            TimestampBehavior::className()
+            TimestampBehavior::class
         ];
     }
 
@@ -139,7 +139,7 @@ class UserToken extends ActiveRecord
      */
     public function getUser()
     {
-        return $this->hasOne(User::className(), ['id' => 'user_id']);
+        return $this->hasOne(User::class, ['id' => 'user_id']);
     }
 
     /**

--- a/common/models/WidgetCarousel.php
+++ b/common/models/WidgetCarousel.php
@@ -35,12 +35,12 @@ class WidgetCarousel extends ActiveRecord
     {
         return [
             'cacheInvalidate' => [
-                'class' => CacheInvalidateBehavior::className(),
+                'class' => CacheInvalidateBehavior::class,
                 'cacheComponent' => 'frontendCache',
                 'keys' => [
                     function ($model) {
                         return [
-                            self::className(),
+                            self::class,
                             $model->key
                         ];
                     }
@@ -79,6 +79,6 @@ class WidgetCarousel extends ActiveRecord
      */
     public function getItems()
     {
-        return $this->hasMany(WidgetCarouselItem::className(), ['carousel_id' => 'id']);
+        return $this->hasMany(WidgetCarouselItem::class, ['carousel_id' => 'id']);
     }
 }

--- a/common/models/WidgetCarouselItem.php
+++ b/common/models/WidgetCarouselItem.php
@@ -59,21 +59,21 @@ class WidgetCarouselItem extends ActiveRecord
     public function behaviors()
     {
         return [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
             [
-                'class' => UploadBehavior::className(),
+                'class' => UploadBehavior::class,
                 'attribute' => 'image',
                 'pathAttribute' => 'path',
                 'baseUrlAttribute' => 'base_url',
                 'typeAttribute' => 'type'
             ],
             'cacheInvalidate' => [
-                'class' => CacheInvalidateBehavior::className(),
+                'class' => CacheInvalidateBehavior::class,
                 'cacheComponent' => 'frontendCache',
                 'keys' => [
                     function ($model) {
                         return [
-                            WidgetCarousel::className(),
+                            WidgetCarousel::class,
                             $model->carousel->key
                         ];
                     }
@@ -120,6 +120,6 @@ class WidgetCarouselItem extends ActiveRecord
      */
     public function getCarousel()
     {
-        return $this->hasOne(WidgetCarousel::className(), ['id' => 'carousel_id']);
+        return $this->hasOne(WidgetCarousel::class, ['id' => 'carousel_id']);
     }
 }

--- a/common/models/WidgetMenu.php
+++ b/common/models/WidgetMenu.php
@@ -33,7 +33,7 @@ class WidgetMenu extends ActiveRecord
     {
         return [
             'cacheInvalidate' => [
-                'class' => CacheInvalidateBehavior::className(),
+                'class' => CacheInvalidateBehavior::class,
                 'cacheComponent' => 'frontendCache',
                 'keys' => [
                     function ($model) {
@@ -55,7 +55,7 @@ class WidgetMenu extends ActiveRecord
         return [
             [['key', 'title', 'items'], 'required'],
             [['key'], 'unique'],
-            [['items'], JsonValidator::className()],
+            [['items'], JsonValidator::class],
             [['status'], 'integer'],
             [['key'], 'string', 'max' => 32],
             [['title'], 'string', 'max' => 255]

--- a/common/models/WidgetText.php
+++ b/common/models/WidgetText.php
@@ -35,14 +35,14 @@ class WidgetText extends ActiveRecord
     public function behaviors()
     {
         return [
-            TimestampBehavior::className(),
+            TimestampBehavior::class,
             'cacheInvalidate' => [
-                'class' => CacheInvalidateBehavior::className(),
+                'class' => CacheInvalidateBehavior::class,
                 'cacheComponent' => 'frontendCache',
                 'keys' => [
                     function ($model) {
                         return [
-                            self::className(),
+                            self::class,
                             $model->key
                         ];
                     }

--- a/common/widgets/DbCarousel.php
+++ b/common/widgets/DbCarousel.php
@@ -48,7 +48,7 @@ class DbCarousel extends Carousel
         }
         $this->assetManager = Instance::ensure($this->assetManager, AssetManager::class);
         $cacheKey = [
-            WidgetCarousel::className(),
+            WidgetCarousel::class,
             $this->key
         ];
         $items = Yii::$app->cache->get($cacheKey);

--- a/common/widgets/DbMenu.php
+++ b/common/widgets/DbMenu.php
@@ -30,7 +30,7 @@ class DbMenu extends Menu
     public function init()
     {
         $cacheKey = [
-            WidgetMenu::className(),
+            WidgetMenu::class,
             $this->key
         ];
         $this->items = Yii::$app->cache->get($cacheKey);

--- a/common/widgets/DbText.php
+++ b/common/widgets/DbText.php
@@ -24,7 +24,7 @@ class DbText extends Widget
     public function run()
     {
         $cacheKey = [
-            WidgetText::className(),
+            WidgetText::class,
             $this->key
         ];
         $content = Yii::$app->cache->get($cacheKey);

--- a/composer.lock
+++ b/composer.lock
@@ -59,16 +59,16 @@
         },
         {
             "name": "bower-asset/ace-builds",
-            "version": "v1.3.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ajaxorg/ace-builds.git",
-                "reference": "5c006df7962e86518df3a615c7a4906f88cf0206"
+                "reference": "3459f57252c79bad99246012f9c703f728eb0b7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ajaxorg/ace-builds/zipball/5c006df7962e86518df3a615c7a4906f88cf0206",
-                "reference": "5c006df7962e86518df3a615c7a4906f88cf0206",
+                "url": "https://api.github.com/repos/ajaxorg/ace-builds/zipball/3459f57252c79bad99246012f9c703f728eb0b7a",
+                "reference": "3459f57252c79bad99246012f9c703f728eb0b7a",
                 "shasum": null
             },
             "type": "bower-asset",
@@ -113,16 +113,16 @@
         },
         {
             "name": "bower-asset/blueimp-file-upload",
-            "version": "v9.20.0",
+            "version": "v9.21.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/blueimp/jQuery-File-Upload.git",
-                "reference": "7d1d64e4d4e2a30cd087fe27355183db980aa785"
+                "reference": "e6f059023afdae3efe9ce66970745254caa80256"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/blueimp/jQuery-File-Upload/zipball/7d1d64e4d4e2a30cd087fe27355183db980aa785",
-                "reference": "7d1d64e4d4e2a30cd087fe27355183db980aa785",
+                "url": "https://api.github.com/repos/blueimp/jQuery-File-Upload/zipball/e6f059023afdae3efe9ce66970745254caa80256",
+                "reference": "e6f059023afdae3efe9ce66970745254caa80256",
                 "shasum": null
             },
             "require": {
@@ -347,16 +347,16 @@
         },
         {
             "name": "bower-asset/moment",
-            "version": "2.20.1",
+            "version": "2.21.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/moment/moment.git",
-                "reference": "03073778ec18ee38e179208cd1af899e8d1848dc"
+                "url": "git@github.com:moment/moment.git",
+                "reference": "7c4c091bedb86ca6c1a5c5419ad5204ef3926347"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/moment/moment/zipball/03073778ec18ee38e179208cd1af899e8d1848dc",
-                "reference": "03073778ec18ee38e179208cd1af899e8d1848dc",
+                "url": "https://api.github.com/repos/moment/moment/zipball/7c4c091bedb86ca6c1a5c5419ad5204ef3926347",
+                "reference": "7c4c091bedb86ca6c1a5c5419ad5204ef3926347",
                 "shasum": null
             },
             "type": "bower-asset",
@@ -575,16 +575,16 @@
         },
         {
             "name": "ezyang/htmlpurifier",
-            "version": "v4.9.3",
+            "version": "v4.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ezyang/htmlpurifier.git",
-                "reference": "95e1bae3182efc0f3422896a3236e991049dac69"
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/95e1bae3182efc0f3422896a3236e991049dac69",
-                "reference": "95e1bae3182efc0f3422896a3236e991049dac69",
+                "url": "https://api.github.com/repos/ezyang/htmlpurifier/zipball/d85d39da4576a6934b72480be6978fb10c860021",
+                "reference": "d85d39da4576a6934b72480be6978fb10c860021",
                 "shasum": ""
             },
             "require": {
@@ -618,7 +618,7 @@
             "keywords": [
                 "html"
             ],
-            "time": "2017-06-03T02:28:16+00:00"
+            "time": "2018-02-23T01:58:20+00:00"
         },
         {
             "name": "guzzlehttp/guzzle",
@@ -935,16 +935,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.0.42",
+            "version": "1.0.43",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "09eabc54e199950041aef258a85847676496fe8e"
+                "reference": "1ce7cc142d906ba58dc54c82915d355a9191c8a8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/09eabc54e199950041aef258a85847676496fe8e",
-                "reference": "09eabc54e199950041aef258a85847676496fe8e",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/1ce7cc142d906ba58dc54c82915d355a9191c8a8",
+                "reference": "1ce7cc142d906ba58dc54c82915d355a9191c8a8",
                 "shasum": ""
             },
             "require": {
@@ -1015,7 +1015,7 @@
                 "sftp",
                 "storage"
             ],
-            "time": "2018-01-27T16:03:56+00:00"
+            "time": "2018-03-01T10:27:04+00:00"
         },
         {
             "name": "league/glide",
@@ -1297,16 +1297,16 @@
         },
         {
             "name": "studio-42/elfinder",
-            "version": "2.1.32",
+            "version": "2.1.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Studio-42/elFinder.git",
-                "reference": "1118be362d76b06cd4179a38caa193644f7ae45d"
+                "reference": "2d3a31f70e3c817417913ab54035717f26e3efce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Studio-42/elFinder/zipball/1118be362d76b06cd4179a38caa193644f7ae45d",
-                "reference": "1118be362d76b06cd4179a38caa193644f7ae45d",
+                "url": "https://api.github.com/repos/Studio-42/elFinder/zipball/2d3a31f70e3c817417913ab54035717f26e3efce",
+                "reference": "2d3a31f70e3c817417913ab54035717f26e3efce",
                 "shasum": ""
             },
             "require": {
@@ -1351,7 +1351,7 @@
             ],
             "description": "File manager for web",
             "homepage": "http://elfinder.org",
-            "time": "2018-02-07T00:04:43+00:00"
+            "time": "2018-03-14T08:59:23+00:00"
         },
         {
             "name": "swiftmailer/swiftmailer",
@@ -1410,16 +1410,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v3.4.4",
+            "version": "v3.4.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "8c39071ac9cc7e6d8dab1d556c990dc0d2cc3d30"
+                "reference": "6f5935723c11b4125fc9927db6ad2feaa196e175"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/8c39071ac9cc7e6d8dab1d556c990dc0d2cc3d30",
-                "reference": "8c39071ac9cc7e6d8dab1d556c990dc0d2cc3d30",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/6f5935723c11b4125fc9927db6ad2feaa196e175",
+                "reference": "6f5935723c11b4125fc9927db6ad2feaa196e175",
                 "shasum": ""
             },
             "require": {
@@ -1460,7 +1460,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29T09:03:43+00:00"
+            "time": "2018-02-22T10:48:49+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1582,16 +1582,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v4.0.4",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "e1712002d81de6f39f854bc5bbd9e9f4bb6345b4"
+                "reference": "6ed08502a7c9559da8e60ea343bdbd19c3350b3e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/e1712002d81de6f39f854bc5bbd9e9f4bb6345b4",
-                "reference": "e1712002d81de6f39f854bc5bbd9e9f4bb6345b4",
+                "url": "https://api.github.com/repos/symfony/process/zipball/6ed08502a7c9559da8e60ea343bdbd19c3350b3e",
+                "reference": "6ed08502a7c9559da8e60ea343bdbd19c3350b3e",
                 "shasum": ""
             },
             "require": {
@@ -1627,7 +1627,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29T09:06:29+00:00"
+            "time": "2018-02-19T12:18:43+00:00"
         },
         {
             "name": "trntv/cheatsheet",
@@ -1989,16 +1989,16 @@
         },
         {
             "name": "yiisoft/yii2",
-            "version": "2.0.13.1",
+            "version": "2.0.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii2-framework.git",
-                "reference": "7af96d8da5ea3e9a5dd05d0e734b21c5726a6ddf"
+                "reference": "ef74f3783e964cea477f06e6d6ce209df1f37881"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-framework/zipball/7af96d8da5ea3e9a5dd05d0e734b21c5726a6ddf",
-                "reference": "7af96d8da5ea3e9a5dd05d0e734b21c5726a6ddf",
+                "url": "https://api.github.com/repos/yiisoft/yii2-framework/zipball/ef74f3783e964cea477f06e6d6ce209df1f37881",
+                "reference": "ef74f3783e964cea477f06e6d6ce209df1f37881",
                 "shasum": ""
             },
             "require": {
@@ -2085,7 +2085,7 @@
                 "framework",
                 "yii2"
             ],
-            "time": "2017-11-14T11:08:21+00:00"
+            "time": "2018-03-13T14:15:01+00:00"
         },
         {
             "name": "yiisoft/yii2-authclient",
@@ -2141,16 +2141,16 @@
         },
         {
             "name": "yiisoft/yii2-bootstrap",
-            "version": "2.0.7",
+            "version": "2.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii2-bootstrap.git",
-                "reference": "02a54d868343ed11d02f0f0f8cbbecb590e0cb3f"
+                "reference": "3f49c47924bb9fa5363c3fc7b073d954168cf438"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-bootstrap/zipball/02a54d868343ed11d02f0f0f8cbbecb590e0cb3f",
-                "reference": "02a54d868343ed11d02f0f0f8cbbecb590e0cb3f",
+                "url": "https://api.github.com/repos/yiisoft/yii2-bootstrap/zipball/3f49c47924bb9fa5363c3fc7b073d954168cf438",
+                "reference": "3f49c47924bb9fa5363c3fc7b073d954168cf438",
                 "shasum": ""
             },
             "require": {
@@ -2165,7 +2165,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "yii\\bootstrap\\": ""
+                    "yii\\bootstrap\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2174,8 +2174,22 @@
             ],
             "authors": [
                 {
+                    "name": "Paul Klimov",
+                    "email": "klimov.paul@gmail.com"
+                },
+                {
+                    "name": "Alexander Makarov",
+                    "email": "sam@rmcreative.ru",
+                    "homepage": "http://rmcreative.ru/"
+                },
+                {
+                    "name": "Antonio Ramirez",
+                    "email": "amigo.cobos@gmail.com"
+                },
+                {
                     "name": "Qiang Xue",
-                    "email": "qiang.xue@gmail.com"
+                    "email": "qiang.xue@gmail.com",
+                    "homepage": "http://www.yiiframework.com/"
                 }
             ],
             "description": "The Twitter Bootstrap extension for the Yii framework",
@@ -2183,7 +2197,7 @@
                 "bootstrap",
                 "yii2"
             ],
-            "time": "2017-10-09T19:48:22+00:00"
+            "time": "2018-02-16T10:41:52+00:00"
         },
         {
             "name": "yiisoft/yii2-composer",
@@ -2237,16 +2251,16 @@
         },
         {
             "name": "yiisoft/yii2-httpclient",
-            "version": "2.0.5",
+            "version": "2.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii2-httpclient.git",
-                "reference": "0417cb05f810890297f79877ccf51865834fb394"
+                "reference": "95fc8a943e8abb86e3d0f4eace6f6d1f4ba4f028"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-httpclient/zipball/0417cb05f810890297f79877ccf51865834fb394",
-                "reference": "0417cb05f810890297f79877ccf51865834fb394",
+                "url": "https://api.github.com/repos/yiisoft/yii2-httpclient/zipball/95fc8a943e8abb86e3d0f4eace6f6d1f4ba4f028",
+                "reference": "95fc8a943e8abb86e3d0f4eace6f6d1f4ba4f028",
                 "shasum": ""
             },
             "require": {
@@ -2260,7 +2274,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "yii\\httpclient\\": ""
+                    "yii\\httpclient\\": "src"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2280,7 +2294,7 @@
                 "httpclient",
                 "yii2"
             ],
-            "time": "2017-11-03T11:22:03+00:00"
+            "time": "2018-02-13T15:11:30+00:00"
         },
         {
             "name": "yiisoft/yii2-jui",
@@ -2382,16 +2396,16 @@
     "packages-dev": [
         {
             "name": "behat/gherkin",
-            "version": "v4.4.5",
+            "version": "v4.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Gherkin.git",
-                "reference": "5c14cff4f955b17d20d088dec1bde61c0539ec74"
+                "reference": "74ac03d52c5e23ad8abd5c5cce4ab0e8dc1b530a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/5c14cff4f955b17d20d088dec1bde61c0539ec74",
-                "reference": "5c14cff4f955b17d20d088dec1bde61c0539ec74",
+                "url": "https://api.github.com/repos/Behat/Gherkin/zipball/74ac03d52c5e23ad8abd5c5cce4ab0e8dc1b530a",
+                "reference": "74ac03d52c5e23ad8abd5c5cce4ab0e8dc1b530a",
                 "shasum": ""
             },
             "require": {
@@ -2437,7 +2451,7 @@
                 "gherkin",
                 "parser"
             ],
-            "time": "2016-10-30T11:50:56+00:00"
+            "time": "2017-08-30T11:04:43+00:00"
         },
         {
             "name": "bower-asset/typeahead.js",
@@ -2460,20 +2474,21 @@
         },
         {
             "name": "codeception/codeception",
-            "version": "2.3.8",
+            "version": "2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Codeception/Codeception.git",
-                "reference": "43eade17a8cd68e9cde401e8585b09d11d41b12d"
+                "reference": "c50789a9a62cc0eefc0252e88a5f04f8c47b55f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/43eade17a8cd68e9cde401e8585b09d11d41b12d",
-                "reference": "43eade17a8cd68e9cde401e8585b09d11d41b12d",
+                "url": "https://api.github.com/repos/Codeception/Codeception/zipball/c50789a9a62cc0eefc0252e88a5f04f8c47b55f4",
+                "reference": "c50789a9a62cc0eefc0252e88a5f04f8c47b55f4",
                 "shasum": ""
             },
             "require": {
-                "behat/gherkin": "~4.4.0",
+                "behat/gherkin": "^4.4.0",
+                "codeception/phpunit-wrapper": "^6.0|^7.0",
                 "codeception/stub": "^1.0",
                 "ext-json": "*",
                 "ext-mbstring": "*",
@@ -2481,10 +2496,6 @@
                 "guzzlehttp/guzzle": ">=4.1.4 <7.0",
                 "guzzlehttp/psr7": "~1.0",
                 "php": ">=5.4.0 <8.0",
-                "phpunit/php-code-coverage": ">=2.2.4 <6.0",
-                "phpunit/phpunit": ">=4.8.28 <5.0.0 || >=5.6.3 <7.0",
-                "sebastian/comparator": ">1.1 <3.0",
-                "sebastian/diff": ">=1.4 <3.0",
                 "symfony/browser-kit": ">=2.7 <5.0",
                 "symfony/console": ">=2.7 <5.0",
                 "symfony/css-selector": ">=2.7 <5.0",
@@ -2550,27 +2561,70 @@
                 "functional testing",
                 "unit testing"
             ],
-            "time": "2018-01-27T22:47:33+00:00"
+            "time": "2018-02-27T00:09:12+00:00"
         },
         {
-            "name": "codeception/stub",
-            "version": "1.0.1",
+            "name": "codeception/phpunit-wrapper",
+            "version": "7.0.4",
             "source": {
                 "type": "git",
-                "url": "https://github.com/Codeception/Stub.git",
-                "reference": "673ea54cdd7141e0a5138ad78aaa60751912f573"
+                "url": "https://github.com/Codeception/phpunit-wrapper.git",
+                "reference": "635b5b94fe1ec153dcae74f3aa6b24b02891d1c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Codeception/Stub/zipball/673ea54cdd7141e0a5138ad78aaa60751912f573",
-                "reference": "673ea54cdd7141e0a5138ad78aaa60751912f573",
+                "url": "https://api.github.com/repos/Codeception/phpunit-wrapper/zipball/635b5b94fe1ec153dcae74f3aa6b24b02891d1c4",
+                "reference": "635b5b94fe1ec153dcae74f3aa6b24b02891d1c4",
                 "shasum": ""
             },
             "require": {
-                "phpunit/phpunit-mock-objects": "^2.3|^3.0|^4.0|^5.0"
+                "phpunit/php-code-coverage": "^6.0",
+                "phpunit/phpunit": "^7.0",
+                "sebastian/comparator": "^2.0",
+                "sebastian/diff": "^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8|^5.0|^6.0|^7.0"
+                "codeception/specify": "*",
+                "vlucas/phpdotenv": "^2.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Codeception\\PHPUnit\\": "src\\"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Davert",
+                    "email": "davert.php@resend.cc"
+                }
+            ],
+            "description": "PHPUnit classes used by Codeception",
+            "time": "2018-03-13T02:44:28+00:00"
+        },
+        {
+            "name": "codeception/stub",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Codeception/Stub.git",
+                "reference": "95fb7a36b81890dd2e5163e7ab31310df6f1bb99"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Codeception/Stub/zipball/95fb7a36b81890dd2e5163e7ab31310df6f1bb99",
+                "reference": "95fb7a36b81890dd2e5163e7ab31310df6f1bb99",
+                "shasum": ""
+            },
+            "require": {
+                "phpunit/phpunit-mock-objects": ">2.3 <7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": ">=4.8 <8.0"
             },
             "type": "library",
             "autoload": {
@@ -2583,7 +2637,7 @@
                 "MIT"
             ],
             "description": "Flexible Stub wrapper for PHPUnit's Mock Builder",
-            "time": "2018-01-27T00:37:17+00:00"
+            "time": "2018-02-18T13:56:56+00:00"
         },
         {
             "name": "codeception/verify",
@@ -3119,16 +3173,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.7.4",
+            "version": "1.7.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "9f901e29c93dae4aa77c0bb161df4276f9c9a1be"
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/9f901e29c93dae4aa77c0bb161df4276f9c9a1be",
-                "reference": "9f901e29c93dae4aa77c0bb161df4276f9c9a1be",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/dfd6be44111a7c41c2e884a336cc4f461b3b2401",
+                "reference": "dfd6be44111a7c41c2e884a336cc4f461b3b2401",
                 "shasum": ""
             },
             "require": {
@@ -3178,44 +3232,44 @@
                 "spy",
                 "stub"
             ],
-            "time": "2018-02-11T18:49:29+00:00"
+            "time": "2018-02-19T10:16:54+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "5.3.0",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1"
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/661f34d0bd3f1a7225ef491a70a020ad23a057a1",
-                "reference": "661f34d0bd3f1a7225ef491a70a020ad23a057a1",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f8ca4b604baf23dab89d87773c28cc07405189ba",
+                "reference": "f8ca4b604baf23dab89d87773c28cc07405189ba",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpunit/php-file-iterator": "^1.4.2",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-token-stream": "^2.0.1",
+                "phpunit/php-token-stream": "^3.0",
                 "sebastian/code-unit-reverse-lookup": "^1.0.1",
                 "sebastian/environment": "^3.0",
                 "sebastian/version": "^2.0.1",
                 "theseer/tokenizer": "^1.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
-                "ext-xdebug": "^2.5.5"
+                "ext-xdebug": "^2.6.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.3.x-dev"
+                    "dev-master": "6.0-dev"
                 }
             },
             "autoload": {
@@ -3241,7 +3295,7 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2017-12-06T09:29:45+00:00"
+            "time": "2018-02-02T07:01:41+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -3333,28 +3387,28 @@
         },
         {
             "name": "phpunit/php-timer",
-            "version": "1.0.9",
+            "version": "2.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f"
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
-                "reference": "3dcf38ca72b158baf0bc245e9184d3fdffa9c46f",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/8b8454ea6958c3dee38453d3bd571e023108c91f",
+                "reference": "8b8454ea6958c3dee38453d3bd571e023108c91f",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.3.3 || ^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.0"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "2.0-dev"
                 }
             },
             "autoload": {
@@ -3369,7 +3423,7 @@
             "authors": [
                 {
                     "name": "Sebastian Bergmann",
-                    "email": "sb@sebastian-bergmann.de",
+                    "email": "sebastian@phpunit.de",
                     "role": "lead"
                 }
             ],
@@ -3378,33 +3432,33 @@
             "keywords": [
                 "timer"
             ],
-            "time": "2017-02-26T11:10:40+00:00"
+            "time": "2018-02-01T13:07:23+00:00"
         },
         {
             "name": "phpunit/php-token-stream",
-            "version": "2.0.2",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-token-stream.git",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db"
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/791198a2c6254db10131eecfe8c06670700904db",
-                "reference": "791198a2c6254db10131eecfe8c06670700904db",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-token-stream/zipball/21ad88bbba7c3d93530d93994e0a33cd45f02ace",
+                "reference": "21ad88bbba7c3d93530d93994e0a33cd45f02ace",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2.4"
+                "phpunit/phpunit": "^7.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3427,20 +3481,20 @@
             "keywords": [
                 "tokenizer"
             ],
-            "time": "2017-11-27T05:48:46+00:00"
+            "time": "2018-02-01T13:16:43+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "6.5.6",
+            "version": "7.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe"
+                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3330ef26ade05359d006041316ed0fa9e8e3cefe",
-                "reference": "3330ef26ade05359d006041316ed0fa9e8e3cefe",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
+                "reference": "e2f8aa21bc54b6ba218bdd4f9e0dac1e9bc3b4e9",
                 "shasum": ""
             },
             "require": {
@@ -3452,15 +3506,15 @@
                 "myclabs/deep-copy": "^1.6.1",
                 "phar-io/manifest": "^1.0.1",
                 "phar-io/version": "^1.0",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpspec/prophecy": "^1.7",
-                "phpunit/php-code-coverage": "^5.3",
+                "phpunit/php-code-coverage": "^6.0",
                 "phpunit/php-file-iterator": "^1.4.3",
                 "phpunit/php-text-template": "^1.2.1",
-                "phpunit/php-timer": "^1.0.9",
-                "phpunit/phpunit-mock-objects": "^5.0.5",
+                "phpunit/php-timer": "^2.0",
+                "phpunit/phpunit-mock-objects": "^6.0",
                 "sebastian/comparator": "^2.1",
-                "sebastian/diff": "^2.0",
+                "sebastian/diff": "^3.0",
                 "sebastian/environment": "^3.1",
                 "sebastian/exporter": "^3.1",
                 "sebastian/global-state": "^2.0",
@@ -3468,16 +3522,12 @@
                 "sebastian/resource-operations": "^1.0",
                 "sebastian/version": "^2.0.1"
             },
-            "conflict": {
-                "phpdocumentor/reflection-docblock": "3.0.2",
-                "phpunit/dbunit": "<3.0"
-            },
             "require-dev": {
                 "ext-pdo": "*"
             },
             "suggest": {
                 "ext-xdebug": "*",
-                "phpunit/php-invoker": "^1.1"
+                "phpunit/php-invoker": "^2.0"
             },
             "bin": [
                 "phpunit"
@@ -3485,7 +3535,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "6.5.x-dev"
+                    "dev-master": "7.0-dev"
                 }
             },
             "autoload": {
@@ -3511,33 +3561,30 @@
                 "testing",
                 "xunit"
             ],
-            "time": "2018-02-01T05:57:37+00:00"
+            "time": "2018-02-26T07:03:12+00:00"
         },
         {
             "name": "phpunit/phpunit-mock-objects",
-            "version": "5.0.6",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit-mock-objects.git",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf"
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
-                "reference": "33fd41a76e746b8fa96d00b49a23dadfa8334cdf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit-mock-objects/zipball/e3249dedc2d99259ccae6affbc2684eac37c2e53",
+                "reference": "e3249dedc2d99259ccae6affbc2684eac37c2e53",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.0.5",
-                "php": "^7.0",
+                "php": "^7.1",
                 "phpunit/php-text-template": "^1.2.1",
                 "sebastian/exporter": "^3.1"
             },
-            "conflict": {
-                "phpunit/phpunit": "<6.0"
-            },
             "require-dev": {
-                "phpunit/phpunit": "^6.5"
+                "phpunit/phpunit": "^7.0"
             },
             "suggest": {
                 "ext-soap": "*"
@@ -3545,7 +3592,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.0.x-dev"
+                    "dev-master": "6.0.x-dev"
                 }
             },
             "autoload": {
@@ -3570,7 +3617,7 @@
                 "mock",
                 "xunit"
             ],
-            "time": "2018-01-06T05:45:45+00:00"
+            "time": "2018-02-15T05:27:38+00:00"
         },
         {
             "name": "sebastian/code-unit-reverse-lookup",
@@ -3683,28 +3730,29 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "2.0.1",
+            "version": "3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd"
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
-                "reference": "347c1d8b49c5c3ee30c7040ea6fc446790e6bddd",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/e09160918c66281713f1c324c1f4c4c3037ba1e8",
+                "reference": "e09160918c66281713f1c324c1f4c4c3037ba1e8",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.0"
+                "php": "^7.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^6.2"
+                "phpunit/phpunit": "^7.0",
+                "symfony/process": "^2 || ^3.3 || ^4"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0-dev"
+                    "dev-master": "3.0-dev"
                 }
             },
             "autoload": {
@@ -3729,9 +3777,12 @@
             "description": "Diff implementation",
             "homepage": "https://github.com/sebastianbergmann/diff",
             "keywords": [
-                "diff"
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
             ],
-            "time": "2017-08-03T08:09:46+00:00"
+            "time": "2018-02-01T13:45:15+00:00"
         },
         {
             "name": "sebastian/environment",
@@ -4133,7 +4184,7 @@
         },
         {
             "name": "symfony/browser-kit",
-            "version": "v4.0.4",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/browser-kit.git",
@@ -4190,16 +4241,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v4.0.4",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "36d5b41e7d4e1ccf0370f6babe966c08ef0a1488"
+                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/36d5b41e7d4e1ccf0370f6babe966c08ef0a1488",
-                "reference": "36d5b41e7d4e1ccf0370f6babe966c08ef0a1488",
+                "url": "https://api.github.com/repos/symfony/console/zipball/555c8dbe0ae9e561740451eabdbed2cc554b6a51",
+                "reference": "555c8dbe0ae9e561740451eabdbed2cc554b6a51",
                 "shasum": ""
             },
             "require": {
@@ -4254,20 +4305,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-29T09:06:29+00:00"
+            "time": "2018-02-26T15:55:47+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v4.0.4",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "f97600434e3141ef3cbb9ea42cf500fba88022b7"
+                "reference": "c69f1e93aa898fd9fec627ebef467188151c8dc2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/f97600434e3141ef3cbb9ea42cf500fba88022b7",
-                "reference": "f97600434e3141ef3cbb9ea42cf500fba88022b7",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/c69f1e93aa898fd9fec627ebef467188151c8dc2",
+                "reference": "c69f1e93aa898fd9fec627ebef467188151c8dc2",
                 "shasum": ""
             },
             "require": {
@@ -4307,20 +4358,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03T07:38:00+00:00"
+            "time": "2018-02-03T14:58:37+00:00"
         },
         {
             "name": "symfony/dom-crawler",
-            "version": "v4.0.4",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dom-crawler.git",
-                "reference": "39b785e1cf28e9f21bb601a5d62c4992a8e8a290"
+                "reference": "26726ddc01601dc9393f2afc3369ce1ca64e4537"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/39b785e1cf28e9f21bb601a5d62c4992a8e8a290",
-                "reference": "39b785e1cf28e9f21bb601a5d62c4992a8e8a290",
+                "url": "https://api.github.com/repos/symfony/dom-crawler/zipball/26726ddc01601dc9393f2afc3369ce1ca64e4537",
+                "reference": "26726ddc01601dc9393f2afc3369ce1ca64e4537",
                 "shasum": ""
             },
             "require": {
@@ -4363,20 +4414,20 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03T07:38:00+00:00"
+            "time": "2018-02-22T10:50:29+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v4.0.4",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "74d33aac36208c4d6757807d9f598f0133a3a4eb"
+                "reference": "85eaf6a8ec915487abac52e133efc4a268204428"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/74d33aac36208c4d6757807d9f598f0133a3a4eb",
-                "reference": "74d33aac36208c4d6757807d9f598f0133a3a4eb",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/85eaf6a8ec915487abac52e133efc4a268204428",
+                "reference": "85eaf6a8ec915487abac52e133efc4a268204428",
                 "shasum": ""
             },
             "require": {
@@ -4426,20 +4477,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03T07:38:00+00:00"
+            "time": "2018-02-14T14:11:10+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v4.0.4",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8b08180f2b7ccb41062366b9ad91fbc4f1af8601"
+                "reference": "44a796d2ecc2a16a5fc8f2956a34ee617934d55f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8b08180f2b7ccb41062366b9ad91fbc4f1af8601",
-                "reference": "8b08180f2b7ccb41062366b9ad91fbc4f1af8601",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/44a796d2ecc2a16a5fc8f2956a34ee617934d55f",
+                "reference": "44a796d2ecc2a16a5fc8f2956a34ee617934d55f",
                 "shasum": ""
             },
             "require": {
@@ -4475,20 +4526,20 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-03T07:38:00+00:00"
+            "time": "2018-03-05T18:28:26+00:00"
         },
         {
             "name": "symfony/yaml",
-            "version": "v4.0.4",
+            "version": "v4.0.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028"
+                "reference": "de5f125ea39de846b90b313b2cfb031a0152d223"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
-                "reference": "ffc60bda1d4a00ec0b32eeabf39dc017bf480028",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/de5f125ea39de846b90b313b2cfb031a0152d223",
+                "reference": "de5f125ea39de846b90b313b2cfb031a0152d223",
                 "shasum": ""
             },
             "require": {
@@ -4533,7 +4584,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2018-01-21T19:06:11+00:00"
+            "time": "2018-02-19T20:08:53+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -4674,21 +4725,21 @@
         },
         {
             "name": "yiisoft/yii2-faker",
-            "version": "2.0.3",
+            "version": "2.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/yiisoft/yii2-faker.git",
-                "reference": "b88ca69ee226a3610b2c26c026c3203d7ac50f6c"
+                "reference": "3df62b1dcb272a8413f9c6e532c9d73f325ccde1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/yiisoft/yii2-faker/zipball/b88ca69ee226a3610b2c26c026c3203d7ac50f6c",
-                "reference": "b88ca69ee226a3610b2c26c026c3203d7ac50f6c",
+                "url": "https://api.github.com/repos/yiisoft/yii2-faker/zipball/3df62b1dcb272a8413f9c6e532c9d73f325ccde1",
+                "reference": "3df62b1dcb272a8413f9c6e532c9d73f325ccde1",
                 "shasum": ""
             },
             "require": {
-                "fzaninotto/faker": "*",
-                "yiisoft/yii2": "*"
+                "fzaninotto/faker": "~1.4",
+                "yiisoft/yii2": "~2.0.0"
             },
             "type": "yii2-extension",
             "extra": {
@@ -4717,7 +4768,7 @@
                 "faker",
                 "yii2"
             ],
-            "time": "2015-03-01T06:22:44+00:00"
+            "time": "2018-02-19T20:27:10+00:00"
         },
         {
             "name": "yiisoft/yii2-gii",

--- a/frontend/modules/api/v1/controllers/UserController.php
+++ b/frontend/modules/api/v1/controllers/UserController.php
@@ -29,10 +29,10 @@ class UserController extends ActiveController
         $behaviors = parent::behaviors();
 
         $behaviors['authenticator'] = [
-            'class' => CompositeAuth::className(),
+            'class' => CompositeAuth::class,
             'authMethods' => [
                 [
-                    'class' => HttpBasicAuth::className(),
+                    'class' => HttpBasicAuth::class,
                     'auth' => function ($username, $password) {
                         $user = User::findByLogin($username);
                         return $user->validatePassword($password)
@@ -40,8 +40,8 @@ class UserController extends ActiveController
                             : null;
                     }
                 ],
-                HttpBearerAuth::className(),
-                QueryParamAuth::className()
+                HttpBearerAuth::class,
+                QueryParamAuth::class
             ]
         ];
 

--- a/frontend/modules/user/controllers/DefaultController.php
+++ b/frontend/modules/user/controllers/DefaultController.php
@@ -20,7 +20,7 @@ class DefaultController extends Controller
     {
         return [
             'avatar-upload' => [
-                'class' => UploadAction::className(),
+                'class' => UploadAction::class,
                 'deleteRoute' => 'avatar-delete',
                 'on afterSave' => function ($event) {
                     /* @var $file \League\Flysystem\File */
@@ -30,7 +30,7 @@ class DefaultController extends Controller
                 }
             ],
             'avatar-delete' => [
-                'class' => DeleteAction::className()
+                'class' => DeleteAction::class
             ]
         ];
     }
@@ -42,7 +42,7 @@ class DefaultController extends Controller
     {
         return [
             'access' => [
-                'class' => AccessControl::className(),
+                'class' => AccessControl::class,
                 'rules' => [
                     [
                         'allow' => true,

--- a/frontend/modules/user/controllers/SignInController.php
+++ b/frontend/modules/user/controllers/SignInController.php
@@ -12,7 +12,7 @@ use frontend\modules\user\models\SignupForm;
 use Yii;
 use yii\authclient\AuthAction;
 use yii\base\Exception;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\filters\AccessControl;
 use yii\filters\VerbFilter;
 use yii\helpers\ArrayHelper;
@@ -50,7 +50,7 @@ class SignInController extends \yii\web\Controller
     {
         return [
             'access' => [
-                'class' => AccessControl::className(),
+                'class' => AccessControl::class,
                 'rules' => [
                     [
                         'actions' => [
@@ -77,7 +77,7 @@ class SignInController extends \yii\web\Controller
                 ]
             ],
             'verbs' => [
-                'class' => VerbFilter::className(),
+                'class' => VerbFilter::class,
                 'actions' => [
                     'logout' => ['post']
                 ]
@@ -234,7 +234,7 @@ class SignInController extends \yii\web\Controller
     {
         try {
             $model = new ResetPasswordForm($token);
-        } catch (InvalidParamException $e) {
+        } catch (InvalidArgumentException $e) {
             throw new BadRequestHttpException($e->getMessage());
         }
 

--- a/frontend/modules/user/models/ResetPasswordForm.php
+++ b/frontend/modules/user/models/ResetPasswordForm.php
@@ -4,7 +4,7 @@ namespace frontend\modules\user\models;
 
 use common\models\UserToken;
 use Yii;
-use yii\base\InvalidParamException;
+use yii\base\InvalidArgumentException;
 use yii\base\Model;
 
 /**
@@ -27,12 +27,12 @@ class ResetPasswordForm extends Model
      *
      * @param  string $token
      * @param  array $config name-value pairs that will be used to initialize the object properties
-     * @throws \yii\base\InvalidParamException if token is empty or not valid
+     * @throws \yii\base\InvalidArgumentException if token is empty or not valid
      */
     public function __construct($token, $config = [])
     {
         if (empty($token) || !is_string($token)) {
-            throw new InvalidParamException('Password reset token cannot be blank.');
+            throw new InvalidArgumentException('Password reset token cannot be blank.');
         }
         /** @var UserToken $tokenModel */
         $this->token = UserToken::find()
@@ -42,7 +42,7 @@ class ResetPasswordForm extends Model
             ->one();
 
         if (!$this->token) {
-            throw new InvalidParamException('Wrong password reset token.');
+            throw new InvalidArgumentException('Wrong password reset token.');
         }
         parent::__construct($config);
     }

--- a/frontend/modules/user/views/default/index.php
+++ b/frontend/modules/user/views/default/index.php
@@ -18,7 +18,7 @@ $this->title = Yii::t('frontend', 'User Settings')
     <h2><?php echo Yii::t('frontend', 'Profile settings') ?></h2>
 
     <?php echo $form->field($model->getModel('profile'), 'picture')->widget(
-        Upload::classname(),
+        Upload::class,
         [
             'url' => ['avatar-upload']
         ]

--- a/frontend/views/site/contact.php
+++ b/frontend/views/site/contact.php
@@ -20,7 +20,7 @@ $this->params['breadcrumbs'][] = $this->title;
                 <?php echo $form->field($model, 'email') ?>
                 <?php echo $form->field($model, 'subject') ?>
                 <?php echo $form->field($model, 'body')->textArea(['rows' => 6]) ?>
-                <?php echo $form->field($model, 'verifyCode')->widget(Captcha::className(), [
+                <?php echo $form->field($model, 'verifyCode')->widget(Captcha::class, [
                     'template' => '<div class="row"><div class="col-lg-3">{image}</div><div class="col-lg-6">{input}</div></div>',
                 ]) ?>
                 <div class="form-group">

--- a/tests/backend/_support/_generated/FunctionalTesterActions.php
+++ b/tests/backend/_support/_generated/FunctionalTesterActions.php
@@ -457,9 +457,9 @@ trait FunctionalTesterActions
      * ```php
      * <?php
      * $I->haveFixtures([
-     *     'posts' => PostsFixture::className(),
+     *     'posts' => PostsFixture::class,
      *     'user' => [
-     *         'class' => UserFixture::className(),
+     *         'class' => UserFixture::class,
      *         'dataFile' => '@tests/_data/models/user.php',
      *      ],
      * ]);
@@ -473,7 +473,7 @@ trait FunctionalTesterActions
      * public function _fixtures(){
      *     return [
      *         'user' => [
-     *             'class' => UserFixture::className(),
+     *             'class' => UserFixture::class,
      *             'dataFile' => codecept_data_dir() . 'user.php'
      *         ]
      *     ];
@@ -514,7 +514,7 @@ trait FunctionalTesterActions
      *
      * ```php
      * <?php
-     * $I->haveFixtures(['users' => UserFixture::className()]);
+     * $I->haveFixtures(['users' => UserFixture::class]);
      *
      * $users = $I->grabFixture('users');
      *

--- a/tests/backend/_support/_generated/UnitTesterActions.php
+++ b/tests/backend/_support/_generated/UnitTesterActions.php
@@ -16,9 +16,9 @@ trait UnitTesterActions
      * ```php
      * <?php
      * $I->haveFixtures([
-     *     'posts' => PostsFixture::className(),
+     *     'posts' => PostsFixture::class,
      *     'user' => [
-     *         'class' => UserFixture::className(),
+     *         'class' => UserFixture::class,
      *         'dataFile' => '@tests/_data/models/user.php',
      *      ],
      * ]);
@@ -32,7 +32,7 @@ trait UnitTesterActions
      * public function _fixtures(){
      *     return [
      *         'user' => [
-     *             'class' => UserFixture::className(),
+     *             'class' => UserFixture::class,
      *             'dataFile' => codecept_data_dir() . 'user.php'
      *         ]
      *     ];
@@ -73,7 +73,7 @@ trait UnitTesterActions
      *
      * ```php
      * <?php
-     * $I->haveFixtures(['users' => UserFixture::className()]);
+     * $I->haveFixtures(['users' => UserFixture::class]);
      *
      * $users = $I->grabFixture('users');
      *

--- a/tests/common/_support/FixtureHelper.php
+++ b/tests/common/_support/FixtureHelper.php
@@ -65,59 +65,59 @@ class FixtureHelper extends Module
     {
         return [
             'article' => [
-                'class' => ArticleFixture::className(),
+                'class' => ArticleFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/article.php',
             ],
             'article_category' => [
-                'class' => ArticleCategoryFixture::className(),
+                'class' => ArticleCategoryFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/article_category.php',
             ],
             'article_attachment' => [
-                'class' => ArticleAttachmentFixture::className(),
+                'class' => ArticleAttachmentFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/article_attachment.php',
             ],
             'user' => [
-                'class' => UserFixture::className(),
+                'class' => UserFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/user.php',
             ],
             'user_profile' => [
-                'class' => UserProfileFixture::className(),
+                'class' => UserProfileFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/user_profile.php',
             ],
             'rbac_auth_rule' => [
-                'class' => RbacAuthRuleFixture::className(),
+                'class' => RbacAuthRuleFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/rbac_auth_rule.php',
             ],
             'rbac_auth_item' => [
-                'class' => RbacAuthItemFixture::className(),
+                'class' => RbacAuthItemFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/rbac_auth_item.php',
             ],
             'rbac_auth_item_child' => [
-                'class' => RbacAuthItemChildFixture::className(),
+                'class' => RbacAuthItemChildFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/rbac_auth_item_child.php',
             ],
             'rbac_auth_assignment' => [
-                'class' => RbacAuthAssignmentFixture::className(),
+                'class' => RbacAuthAssignmentFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/rbac_auth_assignment.php',
             ],
             'page' => [
-                'class' => PageFixture::className(),
+                'class' => PageFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/page.php',
             ],
             'widget_carousel' => [
-                'class' => WidgetCarouselFixture::className(),
+                'class' => WidgetCarouselFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/widget_carousel.php',
             ],
             'widget_carousel_item' => [
-                'class' => WidgetCarouselItemFixture::className(),
+                'class' => WidgetCarouselItemFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/widget_carousel_item.php',
             ],
             'widget_text' => [
-                'class' => WidgetTextFixture::className(),
+                'class' => WidgetTextFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/widget_text.php',
             ],
             'widget_menu' => [
-                'class' => WidgetMenuFixture::className(),
+                'class' => WidgetMenuFixture::class,
                 'dataFile' => '@tests/common/fixtures/data/widget_menu.php',
             ]
         ];

--- a/tests/common/_support/_generated/UnitTesterActions.php
+++ b/tests/common/_support/_generated/UnitTesterActions.php
@@ -547,9 +547,9 @@ trait UnitTesterActions
      * ```php
      * <?php
      * $I->haveFixtures([
-     *     'posts' => PostsFixture::className(),
+     *     'posts' => PostsFixture::class,
      *     'user' => [
-     *         'class' => UserFixture::className(),
+     *         'class' => UserFixture::class,
      *         'dataFile' => '@tests/_data/models/user.php',
      *      ],
      * ]);
@@ -563,7 +563,7 @@ trait UnitTesterActions
      * public function _fixtures(){
      *     return [
      *         'user' => [
-     *             'class' => UserFixture::className(),
+     *             'class' => UserFixture::class,
      *             'dataFile' => codecept_data_dir() . 'user.php'
      *         ]
      *     ];
@@ -604,7 +604,7 @@ trait UnitTesterActions
      *
      * ```php
      * <?php
-     * $I->haveFixtures(['users' => UserFixture::className()]);
+     * $I->haveFixtures(['users' => UserFixture::class]);
      *
      * $users = $I->grabFixture('users');
      *

--- a/tests/frontend/_support/_generated/FunctionalTesterActions.php
+++ b/tests/frontend/_support/_generated/FunctionalTesterActions.php
@@ -457,9 +457,9 @@ trait FunctionalTesterActions
      * ```php
      * <?php
      * $I->haveFixtures([
-     *     'posts' => PostsFixture::className(),
+     *     'posts' => PostsFixture::class,
      *     'user' => [
-     *         'class' => UserFixture::className(),
+     *         'class' => UserFixture::class,
      *         'dataFile' => '@tests/_data/models/user.php',
      *      ],
      * ]);
@@ -473,7 +473,7 @@ trait FunctionalTesterActions
      * public function _fixtures(){
      *     return [
      *         'user' => [
-     *             'class' => UserFixture::className(),
+     *             'class' => UserFixture::class,
      *             'dataFile' => codecept_data_dir() . 'user.php'
      *         ]
      *     ];
@@ -514,7 +514,7 @@ trait FunctionalTesterActions
      *
      * ```php
      * <?php
-     * $I->haveFixtures(['users' => UserFixture::className()]);
+     * $I->haveFixtures(['users' => UserFixture::class]);
      *
      * $users = $I->grabFixture('users');
      *

--- a/tests/frontend/_support/_generated/UnitTesterActions.php
+++ b/tests/frontend/_support/_generated/UnitTesterActions.php
@@ -16,9 +16,9 @@ trait UnitTesterActions
      * ```php
      * <?php
      * $I->haveFixtures([
-     *     'posts' => PostsFixture::className(),
+     *     'posts' => PostsFixture::class,
      *     'user' => [
-     *         'class' => UserFixture::className(),
+     *         'class' => UserFixture::class,
      *         'dataFile' => '@tests/_data/models/user.php',
      *      ],
      * ]);
@@ -32,7 +32,7 @@ trait UnitTesterActions
      * public function _fixtures(){
      *     return [
      *         'user' => [
-     *             'class' => UserFixture::className(),
+     *             'class' => UserFixture::class,
      *             'dataFile' => codecept_data_dir() . 'user.php'
      *         ]
      *     ];
@@ -73,7 +73,7 @@ trait UnitTesterActions
      *
      * ```php
      * <?php
-     * $I->haveFixtures(['users' => UserFixture::className()]);
+     * $I->haveFixtures(['users' => UserFixture::class]);
      *
      * $users = $I->grabFixture('users');
      *


### PR DESCRIPTION
- Replace `::className()` calls with `::class`
- Replace usages of `yii\base\InvalidParamException` with `yii\base\InvalidArgumentException`
- compose.lock update (yii up to 2.0.14.2, etc.)

fix #611 